### PR TITLE
BUG: import of psignifit did not reveal functions.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
+#! 
 """
 Created on Sat Dec  5 20:49:14 2015
 
 @author: root
 """
+
+from .psignifit import *
+
+__title__ = 'psignifit'
+__version__ = '0.1'
+__author__ = 'Sophie Laturnus <sophie.laturnus@uni-tuebingen.de> www.wichmann-lab.org'
+__notes__ = 'based on psignifit by Heiko Schuett with help from Felix Wichmann,  Jakob Macke and Stefan Harmeling'
+__license__ = 'GPL, see LICENSE'


### PR DESCRIPTION
Hey there Heiko,

when importing the package from a `sys.path` it only loaded the empty init file.
This should fix it now, making functions available by 
`import psignifit as ps`