### PR TITLE
Fixing fixedPars for now

### DIFF
--- a/psignifit/likelihood.py
+++ b/psignifit/likelihood.py
@@ -90,12 +90,17 @@ def logLikelihood(data,options, args):
             gamma = options['fixedPars'][3]
         if np.isfinite(np.array(options['fixedPars'][4])):
             varscale = options['fixedPars'][4]
-            
-    #issues for automization: limit range for lambda & gamma
-    
-    lamb[np.logical_or(lamb < 0 ,lamb > (1-np.max(gamma)))] = np.nan
-    gamma[np.logical_or(gamma < 0, gamma > (1-np.max(lamb)))] = np.nan
-    varscale[np.logical_or(varscale < 0, varscale > 1)] = np.nan
+        if (lamb<0) or (lamb>(1-gamma)):
+            lamb = np.nan
+        if (gamma<0) or (gamma>(1-lamb)):
+            gamma = np.nan
+        if (varscale<0) or (varscale>1):
+            varscale = np.nan
+    else:        
+        #issues for automization: limit range for lambda & gamma
+        lamb[np.logical_or(lamb < 0 ,lamb > (1-np.max(gamma)))] = np.nan
+        gamma[np.logical_or(gamma < 0, gamma > (1-np.max(lamb)))] = np.nan
+        varscale[np.logical_or(varscale < 0, varscale > 1)] = np.nan
     
     varscaleOrig = np.reshape(varscale, [1,1,1,1,-1]);
 

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -101,10 +101,9 @@ def psignifit(data, optionsIn):
         options['gridSetType'] = 'cumDist'
         
     if not( 'fixedPars' in options.keys()):
-        a = np.empty((5,1))
-        a[:] = np.NaN
-        options['fixedPars'] = a
-        
+        options['fixedPars'] = np.ones(5)*np.nan
+    elif len(options['fixedPars'].shape)>1:
+        options['fixedPars'] = np.squeeze(op['fixedPars'])
     if not('nblocks' in options.keys()):
         options['nblocks'] = 25
     
@@ -255,9 +254,10 @@ def psignifit(data, optionsIn):
         options['borders'] = _b.setBorders(data,options)
     
     border_idx = np.where(np.isnan(options['fixedPars']) == False);
+    print(border_idx)
     if (border_idx[0].size > 0):
-        options['borders'][border_idx[0],0] = border_idx[1]
-        options['borders'][border_idx[0],1] = border_idx[1]
+        options['borders'][border_idx[0],0] = options['fixedPars'][border_idx[0]]
+        options['borders'][border_idx[0],1] = options['fixedPars'][border_idx[0]]
             
     # normalize priors to first choice of borders
     options['priors'] = _p.normalizePriors(options)
@@ -314,7 +314,7 @@ def psignifitFast(data,options):
 
     options['stepN']     = [20,20,10,10,1]
     options['mbStepN']  = [20,20,10,10,1]
-    options['fixedPars'] = [np.NaN,np.NaN,np.NaN,np.NaN,np.array(0.0)]
+    options['fixedPars'] = np.array([np.NaN,np.NaN,np.NaN,np.NaN,0.0])
     options['fastOptim'] = True
     
     res = psignifit(data,options)

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -103,7 +103,7 @@ def psignifit(data, optionsIn):
     if not( 'fixedPars' in options.keys()):
         options['fixedPars'] = np.ones(5)*np.nan
     elif len(options['fixedPars'].shape)>1:
-        options['fixedPars'] = np.squeeze(op['fixedPars'])
+        options['fixedPars'] = np.squeeze(options['fixedPars'])
     if not('nblocks' in options.keys()):
         options['nblocks'] = 25
     

--- a/psignifit/tests/test_CItest.py
+++ b/psignifit/tests/test_CItest.py
@@ -1,4 +1,4 @@
-from psignifit import *
+import psignifit as ps
 
 def test_test():
     assert True

--- a/psignifit/tests/test_basic.py
+++ b/psignifit/tests/test_basic.py
@@ -22,7 +22,7 @@ data = np.array([[0.0010,   45.0000,   90.0000],
 options = dict()
 options['sigmoidName'] = 'norm'   # choose a cumulative Gauss as the sigmoid
 options['expType']     = '2AFC'
-options['fixedPars']   = np.nan*np.ones((5,1))
+options['fixedPars']   = np.nan*np.ones(5)
 options['fixedPars'][2] = 0.01
 options['fixedPars'][3] = 0.5
 res=ps.psignifit(data,options)
@@ -47,3 +47,9 @@ def test_plot2D():
     ps.psigniplot.plot2D(res,0,1,showImediate=False)
     plt.close('all')
     assert True
+
+def test_fixedPars():
+    #Check that fit and borders are actually set to the fixed parametervalues
+    assert np.all(res['Fit'][np.isfinite(options['fixedPars'])]== options['fixedPars'][np.isfinite(options['fixedPars'])])
+    assert np.all(res['options']['borders'][np.isfinite(options['fixedPars']),0]==options['fixedPars'][np.isfinite(options['fixedPars'])])
+    assert np.all(res['options']['borders'][np.isfinite(options['fixedPars']),1]==options['fixedPars'][np.isfinite(options['fixedPars'])])


### PR DESCRIPTION
fixing Bugs with fixedPars, should now be a simple vector. For backward compatibility we squeeze any given array with more dimensions

To keep this running a few lines in the likelihood calculation had to change as they were otherwise trying to index scalars.

A test was also added, which checks that the two values set in the basic test case are actually fixed, i.e. that the Fit and borders values are actually the provided values.