### PR TITLE
small bugfix to estimateType == 'mean'

### DIFF
--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -447,7 +447,7 @@ def psignifitCore(data, options):
     elif options['estimateType'] == 'mean':
         # get mean estimate
         Fit = np.zeros([d,1])
-        for idx in range[0:d]:
+        for idx in range(d):
             Fit[idx] = np.sum(result['marginals'][idx]*result['marginalsW'][idx]*result['marginalsX'][idx])
         
         result['Fit'] = _deepcopy(Fit)


### PR DESCRIPTION
There's a small bug when trying to use estimateType 'mean'. Might be translation error from matlab.