### PR TITLE
Negative sigmoid inversion fix

### DIFF
--- a/psignifit/getSigmoidHandle.py
+++ b/psignifit/getSigmoidHandle.py
@@ -25,7 +25,7 @@ def getSigmoidHandle(options):
     alpha = options['widthalpha']
     sigmoid = options['sigmoidName']
     PC = options['threshPC']
-    if sigmoid[0:2]=='neg':
+    if sigmoid[0:3]=='neg':
         PC = 1-PC;
     
     


### PR DESCRIPTION
Fix the indexing on the sigmoid name to properly pull the first 3 characters and not only the first two.