### PR TITLE
Fix bug on squeezing marginal distributions

### DIFF
--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -377,13 +377,9 @@ def psignifitCore(data, options):
     
     for idx in range(0,d):
         m, mX, mW = marginalize(result,np.array(idx))
-        result['marginals'].append(m)
-        result['marginalsX'].append(mX)
-        result['marginalsW'].append(mW) 
-    
-    result['marginals'] = np.squeeze(result['marginals'])
-    result['marginalsX'] = np.squeeze(result['marginalsX'])
-    result['marginalsW'] = np.squeeze(result['marginalsW'])
+        result['marginals'].append(np.squeeze(m))
+        result['marginalsX'].append(np.squeeze(mX))
+        result['marginalsW'].append(np.squeeze(mW)) 
         
     '''Find point estimate'''
     if (options['estimateType'] in ['MAP','MLE']):


### PR DESCRIPTION
This change appears to fix [issue #67](https://github.com/wichmann-lab/python-psignifit/issues/67).

Core functions were returning an error in computing marginal distributions because `np.squeeze` was being called on a list. It's strange that this bug shows up now where presumably many other users should have encountered it. I suspect it might be caused by some update to `np.squeeze` to change its behaviour.

I have now adjusted to call on the `np.array` output of marginalize before entering in the list. Psignifit tests now pass, and `demo_001.py` produces a plot. 

However, I have not extensively tested whether this preserves the intended functionality of `marginalize` and the `results["marginals"]` values, nor whether this is specific to different versions of Python / numpy. Advice welcome.

