### PR TITLE
Fix priors scaling

### DIFF
--- a/psignifit/_priors.py
+++ b/psignifit/_priors.py
@@ -155,8 +155,9 @@ def setup_priors(custom_priors, bounds, stimulus_range, width_min, width_alpha, 
         priors.update(custom_priors)
     check_priors(priors, stimulus_range, width_min)
 
+    npriors = {}
     for parameter, prior in priors.items():
-        priors[parameter] = normalize_prior(prior, bounds[parameter])
-    return priors
+        npriors[parameter] = normalize_prior(prior, bounds[parameter])
+    return npriors, priors
 
 

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -85,10 +85,10 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         for param, value in conf.fixed_parameters.items():
             bounds[param] = (value, value)
 
-    priors = setup_priors(custom_priors=conf.priors, bounds=bounds,
-                          stimulus_range=stimulus_range, width_min=width_min, width_alpha=conf.width_alpha,
-                          beta_prior=conf.beta_prior, threshold_perc_correct=conf.thresh_PC)
-    fit_dict, posteriors, grid = _fit_parameters(data, bounds, priors, sigmoid, conf.steps_moving_bounds,
+    npriors, priors = setup_priors(custom_priors=conf.priors, bounds=bounds,
+                            stimulus_range=stimulus_range, width_min=width_min, width_alpha=conf.width_alpha,
+                            beta_prior=conf.beta_prior, threshold_perc_correct=conf.thresh_PC)
+    fit_dict, posteriors, grid = _fit_parameters(data, bounds, npriors, sigmoid, conf.steps_moving_bounds,
                                                  conf.max_bound_value, conf.grid_steps)
 
     grid_values = [grid_value for _, grid_value in sorted(grid.items())]


### PR DESCRIPTION
Keep unnormalized priors and return them to the user instead of the normalized one: this way marginals and priors live in the same space and can be compared and plotted