### PR TITLE
Fix check for fixed params when `fixed_params` is None

### DIFF
--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -136,7 +136,7 @@ class Configuration:
 
     def check_experiment_type_matches_fixed_parameters(self, fixed_params, experiment_type):
         if experiment_type == ExperimentType.N_AFC.value:
-            if 'gamma' in fixed_params:
+            if fixed_params is not None and 'gamma' in fixed_params:
                 warnings.warn(
                     f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma must be fixed to 1/n. Ignoring fixed gamma.')
 

--- a/psignifit/tests/test_configuration.py
+++ b/psignifit/tests/test_configuration.py
@@ -2,7 +2,6 @@ import dataclasses
 from unittest.mock import patch
 
 import pytest
-import numpy as np
 
 from psignifit._configuration import Configuration
 from psignifit._utils import PsignifitException
@@ -104,12 +103,9 @@ def test_set_width_min_wrong_type():
 
 def test_warning_for_2afc_and_wrong_gamma():
     sigmoid = "norm"
-    width = 0.3
-    stim_range = [0.001, 0.001 + width * 1.1]
-    threshold = stim_range[1]/3
+    stim_range = [0.001, 0.2]
     lambda_ = 0.0232
     gamma = 0.1
-
 
     options = {}
     options['sigmoid'] = sigmoid  # choose a cumulative Gauss as the sigmoid
@@ -119,7 +115,4 @@ def test_warning_for_2afc_and_wrong_gamma():
     options["stimulus_range"] = stim_range
 
     with pytest.warns(UserWarning, match='gamma was fixed'):
-        conf = Configuration(**options)
-
-
-
+        Configuration(**options)


### PR DESCRIPTION
Fixing the broken tests