### PR TITLE
Fix the calculation of the fine grid

### DIFF
--- a/psignifit/_parameter.py
+++ b/psignifit/_parameter.py
@@ -80,6 +80,7 @@ def masked_parameter_bounds(grid: Dict[str, Optional[np.ndarray]], mesh_mask: np
     """
     new_bounds = dict()
     mask_indices = mesh_mask.nonzero()
+    # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
     for axis, (parameter_name, parameter_values) in enumerate(sorted(grid.items())):
         indices = mask_indices[axis]
         left, right = 0, len(parameter_values) - 1

--- a/psignifit/_parameter.py
+++ b/psignifit/_parameter.py
@@ -87,7 +87,7 @@ def masked_parameter_bounds(grid: Dict[str, Optional[np.ndarray]], mesh_mask: np
             # get the first and last indices for this parameter's mask
             # and enlarged of one element in both directions
             left = max(left, indices.min() - 1)
-            right = min(indices.max(), right)
+            right = min(indices.max() + 1, right)
         # update the bounds
         new_bounds[parameter_name] = (parameter_values[left], parameter_values[right])
     return new_bounds

--- a/psignifit/tests/test_param_recovery.py
+++ b/psignifit/tests/test_param_recovery.py
@@ -76,8 +76,7 @@ def test_parameter_recovery_2afc(sigmoid):
     options = {}
     options['sigmoid'] = sigmoid  # choose a cumulative Gauss as the sigmoid
     options['experiment_type'] = '2AFC'
-    options['fixed_parameters'] = {'lambda': lambda_,
-                                   'gamma': gamma}
+    options['fixed_parameters'] = {'lambda': lambda_}
     options["stimulus_range"] = stim_range
 
     res = psignifit(data, **options)
@@ -111,8 +110,7 @@ def test_parameter_recovery_2afc_eta(eta):
     options = {}
     options['sigmoid'] = sigmoid  # choose a cumulative Gauss as the sigmoid
     options['experiment_type'] = '2AFC'
-    options['fixed_parameters'] = {'lambda': lambda_,
-                                   'gamma': gamma}
+    options['fixed_parameters'] = {'lambda': lambda_}
     options["stimulus_range"] = stim_range
 
     res = psignifit(data, **options)
@@ -128,8 +126,8 @@ def test_parameter_recovery_2afc_eta(eta):
 @pytest.mark.parametrize("fixed_param",  ['lambda', 'gamma', 'eta', 'threshold', 'width'])
 def test_parameter_recovery_fixed_params(fixed_param):
     sigmoid = "norm"
-    width = 0.3000000000123
-    stim_range = [0.001, 0.001 + width * 1.1]
+    width = 0.2000000000123
+    stim_range = [0.001, 0.001 + width * 1.5]
     nsteps = 10
     sim_params = {
         "width" : width,
@@ -167,7 +165,6 @@ def test_parameter_recovery_fixed_params(fixed_param):
 
     for p in ['lambda', 'gamma', 'threshold', 'width', 'eta']:
         # check all other params are estimated correctly
-        #print(p)
         assert np.isclose(res.parameter_estimate[p], sim_params[p], rtol=1e-4, atol=1/40),  f"failed for parameter {p} for estimation with fixed: {fixed_param}."
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    # This is raised when the number of levels is over 25, which is often the case in tests
+    # see psignifit.py, _warn_common_data_mistakes
+    ignore:The data you supplied contained


### PR DESCRIPTION
The optimization of the parameters start with a coarse grid, that is then refined to a finer one around the MAP.
In the calculation of the bounds of the finer grid, the last point was omitted because of a off-by-one issue. The problem had no impact on the calculation of the maximum, because the final optimization is done using gradient descent. Fixing the issue, however, improves the plots and the checks on the posterior.