### PR TITLE
Really silence warnings in tests

### DIFF
--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -139,16 +139,6 @@ class Configuration:
             if fixed_params is not None and 'gamma' in fixed_params:
                 warnings.warn(
                     f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma is automatically fixed to 1/n. Ignoring fixed gamma.')
-        if experiment_type != ExperimentType.EQ_ASYMPTOTE.value:
-            if fixed_params is not None:
-                if 'gamma' in fixed_params:
-                    pass # we assume the user knows what they are doing
-                if 'lambda' in fixed_params:
-                    pass # we assume the user knows what they are doing
-                if 'lambda' in fixed_params and 'gamma' in fixed_params:
-                    if fixed_params['gamma'] != fixed_params['lambda']:
-                        warnings.warn(
-                            f'The parameters lambda and gamma were fixed to different values. In {experiment_type} experiments gamma need to be equal. Ignoring fixed ???.')
 
 
     def check_experiment_type(self, value):

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -138,7 +138,7 @@ class Configuration:
         if experiment_type == ExperimentType.N_AFC.value:
             if fixed_params is not None and 'gamma' in fixed_params:
                 warnings.warn(
-                    f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma must be fixed to 1/n. Ignoring fixed gamma.')
+                    f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma is automatically fixed to 1/n. Ignoring fixed gamma.')
         if experiment_type != ExperimentType.EQ_ASYMPTOTE.value:
             if fixed_params is not None:
                 if 'gamma' in fixed_params:

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -139,6 +139,18 @@ class Configuration:
             if fixed_params is not None and 'gamma' in fixed_params:
                 warnings.warn(
                     f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma is automatically fixed to 1/n. Ignoring fixed gamma.')
+        if experiment_type == ExperimentType.EQ_ASYMPTOTE.value:
+            if fixed_params is not None:
+                if 'gamma' in fixed_params:
+                    pass # we assume the user knows what they are doing
+                if 'lambda' in fixed_params:
+                    pass # we assume the user knows what they are doing
+                if 'lambda' in fixed_params and 'gamma' in fixed_params:
+                    if fixed_params['gamma'] != fixed_params['lambda']:
+                        raise PsignifitException(
+                            f'The parameters lambda {fixed_params["lambda"]} and'
+                            f' gamma {fixed_params["gamma"]} were fixed to different values.'
+                            f' In {experiment_type} experiments gamma and lambda need to be equal. ')
 
 
     def check_experiment_type(self, value):

--- a/psignifit/tests/test_basic.py
+++ b/psignifit/tests/test_basic.py
@@ -22,8 +22,7 @@ def get_std_options():
     options = dict()
     options['sigmoid'] = 'norm'  # choose a cumulative Gauss as the sigmoid
     options['experiment_type'] = '2AFC'
-    options['fixed_parameters'] = {'lambda': 0.01,
-                                   'gamma': 0.5}
+    options['fixed_parameters'] = {'lambda': 0.01}
     return options
 
 

--- a/psignifit/tests/test_configuration.py
+++ b/psignifit/tests/test_configuration.py
@@ -116,3 +116,21 @@ def test_warning_for_2afc_and_wrong_gamma():
 
     with pytest.warns(UserWarning, match='gamma was fixed'):
         Configuration(**options)
+
+def test_warning_for_equal_asymptote_fixing_lambda_and_gamma():
+    sigmoid = "norm"
+    stim_range = [0.001, 0.2]
+    lambda_ = 0.2
+    gamma = 0.1
+
+    options = {}
+    options['sigmoid'] = sigmoid  # choose a cumulative Gauss as the sigmoid
+    options['experiment_type'] = 'equal asymptote'
+    options['fixed_parameters'] = {'lambda': lambda_,
+                                   'gamma': gamma}
+    options["stimulus_range"] = stim_range
+
+    with pytest.raises(PsignifitException, match='were fixed to different values'):
+        Configuration(**options)
+
+

--- a/psignifit/tests/test_param_recovery.py
+++ b/psignifit/tests/test_param_recovery.py
@@ -4,8 +4,10 @@ import pytest
 from psignifit import psignifit
 from psignifit.sigmoids import ALL_SIGMOID_NAMES
 from psignifit.tools import psychometric, psychometric_with_eta
+from psignifit._utils import fp_error_handler
 
 @pytest.mark.parametrize("sigmoid", list(ALL_SIGMOID_NAMES))
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_parameter_recovery_2afc(sigmoid):
     width = 0.3
     stim_range = [0.01, 0.01 + width * 1.1]
@@ -37,6 +39,7 @@ def test_parameter_recovery_2afc(sigmoid):
 
 
 @pytest.mark.parametrize("eta", [0.1, 0.2, 0.3])
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_parameter_recovery_2afc_eta(random_state, eta):
     sigmoid = "norm"
     width = 0.1
@@ -72,6 +75,7 @@ def test_parameter_recovery_2afc_eta(random_state, eta):
 
 # threshold and width can not be fixed.
 @pytest.mark.parametrize("fixed_param",  ['lambda', 'gamma', 'eta', 'threshold', 'width'])
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_parameter_recovery_fixed_params(fixed_param):
     sigmoid = "norm"
     width = 0.2000000000123
@@ -117,6 +121,7 @@ def test_parameter_recovery_fixed_params(fixed_param):
 
 
 @pytest.mark.parametrize("sigmoid", list(ALL_SIGMOID_NAMES))
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_parameter_recovery_YN(sigmoid):
     width = 0.3
     stim_range = [0.001, 0.001 + width * 1.1]
@@ -149,6 +154,7 @@ def test_parameter_recovery_YN(sigmoid):
 
 
 @pytest.mark.parametrize("sigmoid", list(ALL_SIGMOID_NAMES))
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_parameter_recovery_eq_asymptote(sigmoid):
     width = 0.3
     stim_range = [0.001, 0.001 + width * 1.1]

--- a/psignifit/tests/test_posterior.py
+++ b/psignifit/tests/test_posterior.py
@@ -9,7 +9,7 @@ from psignifit import Configuration
 from psignifit._priors import default_prior
 from psignifit._parameter import parameter_bounds
 from psignifit import _posterior
-from psignifit import _utils
+from psignifit._utils import fp_error_handler
 
 from .data import DATA
 
@@ -44,6 +44,7 @@ def setup_experiment(**kwargs):
         ("equal asymptote", (20, 10, 30, 40), -560.8881),  # gamma is none in grid
     ]
 )
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_log_posterior(experiment_type, result_shape, result_max):
     data, sigmoid, priors, grid = setup_experiment(experiment_type=experiment_type)
     if experiment_type == "equal asymptote":
@@ -55,6 +56,7 @@ def test_log_posterior(experiment_type, result_shape, result_max):
     np.testing.assert_allclose(log_pp.max(), result_max, rtol=1e-5)
 
 
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_log_posterior_zero_eta():
     data, sigmoid, priors, grid = setup_experiment(experiment_type='yes/no')
     grid['eta'] = np.array([0])
@@ -76,6 +78,7 @@ MAX = .097163
         ("equal asymptote", (20, 10, 30, 40), MAX),  # gamma is none in grid
     ]
 )
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_posterior_grid(experiment_type, result_shape, result_max):
     data, sigmoid, priors, grid = setup_experiment(experiment_type=experiment_type)
 
@@ -96,6 +99,7 @@ def test_posterior_grid(experiment_type, result_shape, result_max):
         ("equal asymptote", (20, 10, 30, 40), MAX),  # gamma is none in grid
     ]
 )
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_max_posterior(experiment_type, result_shape, result_max):
     data, sigmoid, priors, grid = setup_experiment(experiment_type=experiment_type)
     __, init_param = _posterior.posterior_grid(data, sigmoid, priors, grid)
@@ -114,6 +118,7 @@ def test_max_posterior(experiment_type, result_shape, result_max):
         assert 'gamma' not in max_param
 
 
+@fp_error_handler(over='ignore', invalid='ignore')
 def test_integral_weights():
     # Simple case
     weights = psignifit._posterior.integral_weights([[0, 1], [0, 1], [0, 1]])

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 filterwarnings =
     # This is raised when the number of levels is over 25, which is often the case in tests
     # see psignifit.py, _warn_common_data_mistakes
+    ignore:Expects at most 25 blocks in data, got
     ignore:The data you supplied contained


### PR DESCRIPTION
Removed the last sources of spurious warnings emitted while running tests.

@lschwetlick : please could you double check this commit ec4e71629b9974f90343a2fcd7ae8ab0046681ce ?
That warning was added by you but I actually think it is wrong. The warning was issued when in an experiment type different from equal asymptote the lambda and gamma where both set but different? If at all it should be the other way around, in the sense that we should warn _only_ in the equal asymptote case. Or am I misunderstanding something?