### PR TITLE
fixes all plot functions

### DIFF
--- a/psignifit/psigniplot.py
+++ b/psignifit/psigniplot.py
@@ -289,14 +289,14 @@ def plot_2D_margin(result: Result,
     if ax is None:
         ax = plt.gca()
     if result.debug=={}:
-        raise ValueError("Expects the posterior mass saved in result, got None. You could try psignifit(debug=True).")
+        raise ValueError("Expects posterior_mass in result, got None. You could try psignifit(debug=True).")
 
     parameter_indices = {param: i for i, param in enumerate(sorted(result.parameter_estimate.keys()))}
     other_param_ix = tuple(i for param, i in parameter_indices.items()
                            if param != first_param and param != second_param)
     marginal_2d = np.sum(result.debug['posteriors'], axis=other_param_ix)
     if len(np.squeeze(marginal_2d).shape) != 2 or np.any(np.array(marginal_2d.shape) == 1):
-        raise ValueError('The marginal is not two-dimensional. Were the parameters fixed during optimization? If so, then use plot_marginal() to obtain the marginal for the unfixed parameter.')
+        raise ValueError('The marginal is not two-dimensional. Were the parameters fixed during optimization? If so, then change the arguments to parametes that were unfixed, or use plot_marginal() to obtain a 1D marginal for a parameter.')
 
     if parameter_indices[first_param] > parameter_indices[second_param]:
         marginal_2d = np.transpose(marginal_2d)

--- a/psignifit/psigniplot.py
+++ b/psignifit/psigniplot.py
@@ -161,6 +161,46 @@ def plot_modelfit(result: Result) -> matplotlib.figure.Figure:
     return fig
 
 
+def plot_bayes(result: Result) -> matplotlib.figure.Figure:
+    """ Plot all posteriors 
+
+    Plots 2D marginals for all combinations of parameters.
+    """
+    if result.debug=={}:
+        raise ValueError("Expects posterior_mass in result, got None. You could try psignifit(debug=True).")
+        
+    fig, axes = plt.subplots(4, 4, figsize=(14, 12))
+    panel_indices = {'threshold': 0,
+                     'width': 1,
+                     'lambda': 2,
+                     'gamma': 3,
+                     'eta': 4}
+    for yparam, i in panel_indices.items():
+        for xparam, j in panel_indices.items():
+            if yparam == xparam or i>j:
+                continue
+            try:
+                plot_2D_margin(result, yparam, xparam, ax=axes[i][j-1])
+            except ValueError:
+                if len(result.parameter_values[xparam])==1:
+                    fixedparam = xparam
+                elif len(result.parameter_values[yparam])==1:
+                    fixedparam = yparam
+                axes[i][j-1].text(0.5, 0.5, 
+                                  f"Parameter {fixedparam} was\nfixed during fitting,\nthere is no data to show", 
+                                  ha='center')
+                axes[i][j-1].axis("off")
+
+    # hide unused axes
+    axes[1][0].axis("off")
+    axes[2][0].axis("off")
+    axes[3][0].axis("off")
+    axes[2][1].axis("off")
+    axes[3][1].axis("off")
+    axes[3][2].axis("off")
+    plt.tight_layout()
+    return fig
+
 def plot_marginal(result: Result,
                   parameter: str,
                   ax: matplotlib.axes.Axes = None,
@@ -315,7 +355,7 @@ def plot_2D_margin(result: Result,
         marginal_2d = np.transpose(marginal_2d)
     extent = [result.parameter_values[second_param][0], result.parameter_values[second_param][-1],
               result.parameter_values[first_param][0], result.parameter_values[first_param][-1]]
-    ax.imshow(marginal_2d, extent=extent, cmap='OrRd_r',  aspect='auto')
+    ax.imshow(marginal_2d, extent=extent, cmap='Reds_r',  aspect='auto')
     ax.set_xlabel(_parameter_label(second_param))
     ax.set_ylabel(_parameter_label(first_param))
 

--- a/psignifit/psigniplot.py
+++ b/psignifit/psigniplot.py
@@ -289,20 +289,20 @@ def plot_2D_margin(result: Result,
     if ax is None:
         ax = plt.gca()
     if result.debug=={}:
-        raise ValueError("Expects posterior_mass in result, got None. You could try psignifit(debug=True).")
+        raise ValueError("Expects the posterior mass saved in result, got None. You could try psignifit(debug=True).")
 
     parameter_indices = {param: i for i, param in enumerate(sorted(result.parameter_estimate.keys()))}
     other_param_ix = tuple(i for param, i in parameter_indices.items()
                            if param != first_param and param != second_param)
     marginal_2d = np.sum(result.debug['posteriors'], axis=other_param_ix)
-    if len(marginal_2d.shape) != 2 or np.any(marginal_2d.shape == 1):
-        raise ValueError(f'The marginal is not two-dimensional. Were the parameters fixed during optimization?')
+    if len(np.squeeze(marginal_2d).shape) != 2 or np.any(np.array(marginal_2d.shape) == 1):
+        raise ValueError('The marginal is not two-dimensional. Were the parameters fixed during optimization? If so, then use plot_marginal() to obtain the marginal for the unfixed parameter.')
 
     if parameter_indices[first_param] > parameter_indices[second_param]:
-        (second_param, first_param) = (first_param, second_param)
+        marginal_2d = np.transpose(marginal_2d)
     extent = [result.parameter_values[second_param][0], result.parameter_values[second_param][-1],
               result.parameter_values[first_param][0], result.parameter_values[first_param][-1]]
-    ax.imshow(marginal_2d, extent=extent)
+    ax.imshow(marginal_2d, extent=extent, cmap='OrRd_r',  aspect='auto')
     ax.set_xlabel(_parameter_label(second_param))
     ax.set_ylabel(_parameter_label(first_param))
 


### PR DESCRIPTION
-  2D marginal plot. Automatic swapping of axes is removed because it was a very confusing behavior and only depended on the alphabetical order of the parameters (indices).
- priors plot fixed with same range as in MATLAB version. Previous version to set the range was hacky.
- bayes plot, which was missing in the python implementation, now implemented for all combinations of non-fixed parameters.