### PR TITLE
Improve sigmoid tests, fix bug in Gaussian._slope

### DIFF
--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -147,8 +147,8 @@ class Sigmoid:
 class Gaussian(Sigmoid):
     """ Sigmoid based on the Gaussian distribution's CDF. """
     def _value(self, stimulus_level, threshold, width):
-        C = width / (norminv(1 - self.alpha) - norminv(self.alpha))
-        return normcdf(stimulus_level, (threshold - norminvg(self._PC, 0, C)), C)
+        C =(norminv(1 - self.alpha) - norminv(self.alpha))
+        return normcdf(stimulus_level, (threshold - norminvg(self._PC, 0,  width / C)),  width / C)
 
     def _slope(self, stimulus_level: np.ndarray, threshold: np.ndarray, width: np.ndarray) -> np.ndarray:
         C = norminv(1 - self.alpha) - norminv(self.alpha)

--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -58,10 +58,6 @@ class Sigmoid:
         self.alpha = alpha
         self.negative = negative
         self.PC = PC
-        # if negative:
-        #     self.PC = 1 - PC
-        # else:
-        #     self.PC = PC
 
     def __eq__(self, o: object) -> bool:
         return (isinstance(o, self.__class__)
@@ -128,9 +124,7 @@ class Sigmoid:
             if (prop_correct < gamma).any() or (prop_correct > (1 - lambd)).any():
                 raise ValueError(f'prop_correct={prop_correct} has to be between {gamma} and {1 - lambd}.')
             prop_correct = (prop_correct - gamma) / (1 - lambd - gamma)
-        PC = self.PC
         if self.negative:
-            PC = 1 - PC
             prop_correct = 1 - prop_correct
 
         result = self._inverse(prop_correct, threshold, width)

--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -57,10 +57,11 @@ class Sigmoid:
         """
         self.alpha = alpha
         self.negative = negative
-        if negative:
-            self.PC = 1 - PC
-        else:
-            self.PC = PC
+        self.PC = PC
+        # if negative:
+        #     self.PC = 1 - PC
+        # else:
+        #     self.PC = PC
 
     def __eq__(self, o: object) -> bool:
         return (isinstance(o, self.__class__)
@@ -143,73 +144,6 @@ class Sigmoid:
 
     def _inverse(self, prop_correct: np.ndarray, threshold: np.ndarray, width: np.ndarray) -> np.ndarray:
         raise NotImplementedError("This should be overwritten by an implementation.")
-
-    def assert_sanity_checks(self, n_samples: int, threshold: float, width: float):
-        """ Assert multiple sanity checks on this sigmoid implementation.
-
-        These checks cannot completely assure the correct implementation of a sigmoid,
-        but try to catch common and obvious mistakes.
-        We recommend to use these for custom sigmoid subclasses.
-
-        The checks are performed on linear spaced stimulus levels between 0 and 1
-        and the provided sigmoid parameters.
-
-        Two checks for relations between parameters:
-          - `sigmoid(threshold_stimulus_level) == threshold_percent_correct`
-          - `|X_L - X_R| == width`
-            with `sigmoid(X_L) == alpha`
-            and  `sigmoid(X_R) == 1 - alpha`
-
-        Two checks for the inverse:
-          - `inverse(PC) == threshold_stimulus_level`
-          - `inverse(inverse(stimulus_levels) == stimulus_levels`
-
-        Two checks for the slope:
-          - `maximum(|slope(stimulus_levels)|)` close to `|slope(0.5)|`
-          - `slope(stimulus_levels) > 0`  (or < 0 for negative sigmoid)
-
-        Args:
-             n_samples: Number of stimulus levels between 0 (exclusive) and 1 for tests
-             threshold: Parameter value for threshold at PC
-             width: Width of the sigmoid
-        Raises:
-              AssertionError if a sanity check fails.
-        """
-        stimulus_levels = np.linspace(1e-8, 1, n_samples)
-        threshold_stimulus_level = threshold
-        if self.negative:
-            stimulus_levels = 1 - stimulus_levels
-
-        # sigmoid(threshold_stimulus_level) == threshold_percent_correct
-        np.testing.assert_allclose(self(threshold_stimulus_level, threshold, width), self.PC)
-        # |X_L - X_R| == WIDTH, with
-        # with sigmoid(X_L) == ALPHA
-        # and  sigmoid(X_R) == 1 - ALPHA
-        prop_correct = self(stimulus_levels, threshold, width)
-        idx_alpha, idx_nalpha = (np.abs(prop_correct - self.alpha).argmin(),
-                                 np.abs(prop_correct - (1 - self.alpha)).argmin())
-        np.testing.assert_allclose(prop_correct[idx_nalpha] - prop_correct[idx_alpha], width, atol=0.02)
-
-        # Inverse sigmoid at threshold proportion correct (y-axis)
-        # Expects the threshold stimulus level (x-axis).
-        stimulus_level_from_inverse = self.inverse(self.PC,
-                                                   threshold=threshold,
-                                                   width=width)
-        np.testing.assert_allclose(stimulus_level_from_inverse, threshold_stimulus_level)
-        # Expects inverse(value(x)) == x
-        y = self(stimulus_levels, threshold=threshold, width=width)
-        np.testing.assert_allclose(stimulus_levels,
-                                   self.inverse(y, threshold=threshold, width=width),
-                                   atol=1e-9)
-
-        slope = self.slope(stimulus_levels, threshold=threshold, width=width, gamma=0, lambd=0)
-        # Expects maximal slope at a medium stimulus level
-        assert 0.4 * len(slope) < np.argmax(np.abs(slope)) < 0.6 * len(slope)
-        # Expects slope to be all positive/negative for standard/decreasing sigmoid
-        if self.negative:
-            assert np.all(slope < 0)
-        else:
-            assert np.all(slope > 0)
 
 
 class Gaussian(Sigmoid):

--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -143,77 +143,6 @@ class Sigmoid:
     def _inverse(self, prop_correct: np.ndarray, threshold: np.ndarray, width: np.ndarray) -> np.ndarray:
         raise NotImplementedError("This should be overwritten by an implementation.")
 
-    def assert_sanity_checks(self, n_samples: int, threshold: float, width: float):
-        """ Assert multiple sanity checks on this sigmoid implementation.
-
-        These checks cannot completely assure the correct implementation of a sigmoid,
-        but try to catch common and obvious mistakes.
-        We recommend to use these for custom sigmoid subclasses.
-
-        The checks are performed on linear spaced stimulus levels between 0 and 1
-        and the provided sigmoid parameters.
-
-        Two checks for relations between parameters:
-          - `sigmoid(threshold_stimulus_level) == threshold_percent_correct`
-          - `|X_L - X_R| == width`
-            with `sigmoid(X_L) == alpha`
-            and  `sigmoid(X_R) == 1 - alpha`
-
-        Two checks for the inverse:
-          - `inverse(PC) == threshold_stimulus_level`
-          - `inverse(inverse(stimulus_levels) == stimulus_levels`
-
-        Two checks for the slope:
-          - `maximum(|slope(stimulus_levels)|)` close to `|slope(0.5)|`
-          - `slope(stimulus_levels) > 0`  (or < 0 for negative sigmoid)
-
-        Args:
-             n_samples: Number of stimulus levels between 0 (exclusive) and 1 for tests
-             threshold: Parameter value for threshold at PC
-             width: Width of the sigmoid
-        Raises:
-              AssertionError if a sanity check fails.
-        """
-        stimulus_levels = np.linspace(1e-8, 1, n_samples)
-        threshold_stimulus_level = threshold
-
-        # sigmoid(threshold_stimulus_level) == threshold_percent_correct
-        np.testing.assert_allclose(self(threshold_stimulus_level, threshold, width), self.PC)
-        # |X_L - X_R| == WIDTH, with
-        # with sigmoid(X_L) == ALPHA
-        # and  sigmoid(X_R) == 1 - ALPHA
-        prop_correct = self(stimulus_levels, threshold, width)
-        # When the sigmoid is negative, it is decreasing, so we compute the width on 1-prop_correct
-        # (Alternatively, we could have used `argmax` and swapped the indices)
-        if self.negative:
-            stimulus_levels = 1 - stimulus_levels
-        idx_alpha, idx_nalpha = (np.abs(prop_correct - self.alpha).argmin(),
-                                 np.abs(prop_correct - (1 - self.alpha)).argmin())
-        np.testing.assert_allclose(
-            stimulus_levels[idx_nalpha] - stimulus_levels[idx_alpha],
-            width, atol=0.02)
-
-        # Inverse sigmoid at threshold proportion correct (y-axis)
-        # Expects the threshold stimulus level (x-axis).
-        stimulus_level_from_inverse = self.inverse(self.PC,
-                                                   threshold=threshold,
-                                                   width=width)
-        np.testing.assert_allclose(stimulus_level_from_inverse, threshold_stimulus_level)
-        # Expects inverse(value(x)) == x
-        y = self(stimulus_levels, threshold=threshold, width=width)
-        np.testing.assert_allclose(stimulus_levels,
-                                   self.inverse(y, threshold=threshold, width=width),
-                                   atol=1e-8)
-
-        slope = self.slope(stimulus_levels, threshold=threshold, width=width, gamma=0, lambd=0)
-        # Expects maximal slope at a medium stimulus level
-        assert 0.3 * len(slope) < np.argmax(np.abs(slope)) < 0.7 * len(slope)
-        # Expects slope to be all positive/negative for standard/decreasing sigmoid
-        if self.negative:
-            assert np.all(slope < 0)
-        else:
-            assert np.all(slope > 0)
-
 
 class Gaussian(Sigmoid):
     """ Sigmoid based on the Gaussian distribution's CDF. """
@@ -349,3 +278,75 @@ def sigmoid_by_name(name, PC=None, alpha=None):
         kwargs['negative'] = True
 
     return _CLASS_BY_NAME[name](**kwargs)
+
+
+def assert_sigmoid_sanity_checks(sigmoid, n_samples: int, threshold: float, width: float):
+    """ Assert multiple sanity checks on this sigmoid implementation.
+
+    This is support code to have a first sanity check for  custom sigmoid subclasses.
+    These checks cannot completely assure the correct implementation of a sigmoid,
+    but try to catch common and obvious mistakes.
+
+    The checks are performed on linear spaced stimulus levels between 0 and 1
+    and the provided sigmoid parameters.
+
+    Two checks for relations between parameters:
+      - `sigmoid(threshold_stimulus_level) == threshold_percent_correct`
+      - `|X_L - X_R| == width`
+        with `sigmoid(X_L) == alpha`
+        and  `sigmoid(X_R) == 1 - alpha`
+
+    Two checks for the inverse:
+      - `inverse(PC) == threshold_stimulus_level`
+      - `inverse(inverse(stimulus_levels) == stimulus_levels`
+
+    Two checks for the slope:
+      - `maximum(|slope(stimulus_levels)|)` close to `|slope(0.5)|`
+      - `slope(stimulus_levels) > 0`  (or < 0 for negative sigmoid)
+
+    Args:
+         n_samples: Number of stimulus levels between 0 (exclusive) and 1 for tests
+         threshold: Parameter value for threshold at PC
+         width: Width of the sigmoid
+    Raises:
+          AssertionError if a sanity check fails.
+    """
+    stimulus_levels = np.linspace(1e-8, 1, n_samples)
+    threshold_stimulus_level = threshold
+
+    # sigmoid(threshold_stimulus_level) == threshold_percent_correct
+    np.testing.assert_allclose(sigmoid(threshold_stimulus_level, threshold, width), sigmoid.PC)
+    # |X_L - X_R| == WIDTH, with
+    # with sigmoid(X_L) == ALPHA
+    # and  sigmoid(X_R) == 1 - ALPHA
+    prop_correct = sigmoid(stimulus_levels, threshold, width)
+    # When the sigmoid is negative, it is decreasing, so we compute the width on 1-prop_correct
+    # (Alternatively, we could have used `argmax` and swapped the indices)
+    if sigmoid.negative:
+        stimulus_levels = 1 - stimulus_levels
+    idx_alpha, idx_nalpha = (np.abs(prop_correct - sigmoid.alpha).argmin(),
+                             np.abs(prop_correct - (1 - sigmoid.alpha)).argmin())
+    np.testing.assert_allclose(
+        stimulus_levels[idx_nalpha] - stimulus_levels[idx_alpha],
+        width, atol=0.02)
+
+    # Inverse sigmoid at threshold proportion correct (y-axis)
+    # Expects the threshold stimulus level (x-axis).
+    stimulus_level_from_inverse = sigmoid.inverse(sigmoid.PC,
+                                                  threshold=threshold,
+                                                  width=width)
+    np.testing.assert_allclose(stimulus_level_from_inverse, threshold_stimulus_level)
+    # Expects inverse(value(x)) == x
+    y = sigmoid(stimulus_levels, threshold=threshold, width=width)
+    np.testing.assert_allclose(stimulus_levels,
+                               sigmoid.inverse(y, threshold=threshold, width=width),
+                               atol=1e-8)
+
+    slope = sigmoid.slope(stimulus_levels, threshold=threshold, width=width, gamma=0, lambd=0)
+    # Expects maximal slope at a medium stimulus level
+    assert 0.3 * len(slope) < np.argmax(np.abs(slope)) < 0.7 * len(slope)
+    # Expects slope to be all positive/negative for standard/decreasing sigmoid
+    if sigmoid.negative:
+        assert np.all(slope < 0)
+    else:
+        assert np.all(slope > 0)

--- a/psignifit/tests/test_sigmoids.py
+++ b/psignifit/tests/test_sigmoids.py
@@ -24,27 +24,10 @@ def test_sigmoid_by_name(sigmoid_name):
 
     s = sigmoids.sigmoid_by_name(sigmoid_name, PC=0.2, alpha=0.132)
     assert isinstance(s, sigmoids.Sigmoid)
+    assert s.PC == 0.2
+    assert s.alpha == 0.132
 
     assert sigmoid_name.startswith('neg_') == s.negative
-
-
-@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
-def test_sigmoid_sanity_check(sigmoid_name):
-    """ Basic sanity checks for sigmoids.
-
-    These sanity checks test some basic relations between the parameters
-    as well as rule of thumbs which can be derived from visual inspection
-    of the sigmoid functions.
-    """
-    # fixed parameters for simple sigmoid sanity checks
-    PC = 0.45
-    # Threshold computed by hand to correspond to PC (for negative sigmoids, we'll compare this
-    # threshold with the value at 1 - PC)
-    threshold = 0.54
-    alpha = 0.083
-
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=alpha)
-    sigmoid.assert_sanity_checks(n_samples=10000, threshold=threshold, width=0.7)
 
 
 @pytest.mark.parametrize(
@@ -97,3 +80,24 @@ def test_sigmoid_slope(sigmoid_name):
             / (2 * delta)
     )
     np.testing.assert_allclose(slope, numerical_slope, atol=1e-6)
+
+
+@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
+def test_sigmoid_sanity_check(sigmoid_name):
+    """ Basic sanity checks for sigmoids.
+
+    These sanity checks test some basic relations between the parameters
+    as well as rule of thumbs which can be derived from visual inspection
+    of the sigmoid functions.
+    """
+    # fixed parameters for simple sigmoid sanity checks
+    PC = 0.45
+    # Threshold computed by hand to correspond to PC (for negative sigmoids, we'll compare this
+    # threshold with the value at 1 - PC)
+    threshold = 0.54
+    alpha = 0.083
+
+    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=alpha)
+    sigmoids.assert_sigmoid_sanity_checks(
+        sigmoid, n_samples=10000, threshold=threshold, width=0.7,
+    )

--- a/psignifit/tests/test_sigmoids.py
+++ b/psignifit/tests/test_sigmoids.py
@@ -30,7 +30,7 @@ def test_sigmoid_by_name(sigmoid_name):
     s = sigmoids.sigmoid_by_name(sigmoid_name.upper())
     assert isinstance(s, sigmoids.Sigmoid)
 
-    s = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=ALPHA)
+    s = sigmoids.sigmoid_by_name(sigmoid_name, PC=0.2, alpha=0.132)
     assert isinstance(s, sigmoids.Sigmoid)
 
     assert sigmoid_name.startswith('neg_') == s.negative
@@ -44,16 +44,30 @@ def test_sigmoid_sanity_check(sigmoid_name):
     as well as rule of thumbs which can be derived from visual inspection
     of the sigmoid functions.
     """
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=ALPHA)
-    sigmoid.assert_sanity_checks(n_samples=100,
-                                 threshold=THRESHOLD_PARAM,
-                                 width=WIDTH_PARAM)
+
+    # fixed parameters for simple sigmoid sanity checks
+    PC = 0.4
+    threshold = 0.460172162722971  # Computed by hand to correspond to PC
+    alpha = 0.083
+
+    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=alpha)
+
+    assert_sanity_checks(
+        sigmoid,
+        n_samples=10000,
+        threshold=threshold,
+    )
 
 
 @pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
 def test_sigmoid_roundtrip(sigmoid_name):
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=ALPHA)
-    x = 0.5
-    y = sigmoid(x, THRESHOLD_PARAM, WIDTH_PARAM)
-    reverse_x = sigmoid.inverse(y, THRESHOLD_PARAM, WIDTH_PARAM)
-    assert np.isclose(x, reverse_x, atol=1e-6)
+    pc = 0.7
+    alpha = 0.12
+    threshold = 0.6
+    width = 0.6
+
+    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=pc, alpha=alpha)
+    for x in np.linspace(0.1, 0.9, 10):
+        y = sigmoid(x, threshold, width)
+        reverse_x = sigmoid.inverse(y, threshold, width)
+        assert np.isclose(x, reverse_x, atol=1e-6)

--- a/psignifit/tests/test_sigmoids.py
+++ b/psignifit/tests/test_sigmoids.py
@@ -4,12 +4,82 @@ import pytest
 from psignifit import sigmoids
 
 
-# fixed parameters for simple sigmoid sanity checks
-X = np.linspace(1e-12, 1 - 1e-12, num=10000)
-THRESHOLD_PARAM = 0.5
-WIDTH_PARAM = 0.9
-PC = 0.5
-ALPHA = 0.05
+def assert_sanity_checks(sigmoid, n_samples: int, threshold: float):
+    """ Assert multiple sanity checks on this sigmoid implementation.
+
+    These checks cannot completely assure the correct implementation of a sigmoid,
+    but try to catch common and obvious mistakes.
+    We recommend to use these for custom sigmoid subclasses.
+
+    The checks are performed on linear spaced stimulus levels between 0 and 1
+    and the provided sigmoid parameters.
+
+    Two checks for relations between parameters:
+      - `sigmoid(threshold_stimulus_level) == threshold_percent_correct`
+      - `|X_L - X_R| == width`
+        with `sigmoid(X_L) == alpha`
+        and  `sigmoid(X_R) == 1 - alpha`
+
+    Two checks for the inverse:
+      - `inverse(PC) == threshold_stimulus_level`
+      - `inverse(inverse(stimulus_levels) == stimulus_levels`
+
+    Two checks for the slope:
+      - `maximum(|slope(stimulus_levels)|)` close to `|slope(0.5)|`
+      - `slope(stimulus_levels) > 0`  (or < 0 for negative sigmoid)
+
+    Args:
+        sigmoid : The Sigmoid subclass to test
+        n_samples: Number of stimulus levels between 0 (exclusive) and 1 for tests
+        threshold: Parameter value for threshold at PC
+        width: Width of the sigmoid
+    Raises:
+        AssertionError if a sanity check fails.
+    """
+    stimulus_levels = np.linspace(-0.3, 1.3, n_samples)
+    threshold_stimulus_level = threshold
+    width = 1 - sigmoid.alpha * 2
+
+    # Test that sigmoid(threshold_stimulus_level) == threshold_percent_correct
+    expected_PC = sigmoid.PC
+    if sigmoid.negative:
+        expected_PC = 1 - sigmoid.PC
+    np.testing.assert_allclose(sigmoid(threshold_stimulus_level, threshold, width), expected_PC)
+
+    # Test that the width is equal to the
+    # |X_L - X_R| == WIDTH, with
+    # with sigmoid(X_L) == ALPHA
+    # and  sigmoid(X_R) == 1 - ALPHA
+    prop_correct = sigmoid(stimulus_levels, threshold, width)
+    # When the sigmoid is negative, it is decreasing so we compute the width on 1-prop_correct
+    # (Alternatively, we could have used `argmax` and swapped the indices)
+    if sigmoid.negative:
+        prop_correct = 1 - prop_correct
+    idx_alpha, idx_nalpha = ((prop_correct < sigmoid.alpha).argmin(),
+                             (prop_correct < (1 - sigmoid.alpha)).argmin())
+    np.testing.assert_allclose(prop_correct[idx_nalpha] - prop_correct[idx_alpha], width,
+                               atol=0.02)
+
+    # Inverse sigmoid at threshold proportion correct (y-axis)
+    # Expects the threshold stimulus level (x-axis).
+    stimulus_level_from_inverse = sigmoid.inverse(expected_PC,
+                                                  threshold=threshold,
+                                                  width=width)
+    np.testing.assert_allclose(stimulus_level_from_inverse, threshold_stimulus_level)
+    # Expects inverse(value(x)) == x
+    y = sigmoid(stimulus_levels, threshold=threshold, width=width)
+    np.testing.assert_allclose(stimulus_levels,
+                               sigmoid.inverse(y, threshold=threshold, width=width),
+                               atol=1e-9)
+
+    slope = sigmoid.slope(stimulus_levels, threshold=threshold, width=width, gamma=0, lambd=0)
+    # Expects maximal slope at a medium stimulus level
+    #assert 0.4 * len(slope) < np.argmax(np.abs(slope)) < 0.6 * len(slope)
+    # Expects slope to be all positive/negative for standard/decreasing sigmoid
+    if sigmoid.negative:
+        assert np.all(slope < 0)
+    else:
+        assert np.all(slope > 0)
 
 
 def test_ALL_SIGMOID_NAMES():

--- a/psignifit/tests/test_sigmoids.py
+++ b/psignifit/tests/test_sigmoids.py
@@ -4,82 +4,6 @@ import pytest
 from psignifit import sigmoids
 
 
-def assert_sanity_checks(sigmoid, threshold: float):
-    """ Assert multiple sanity checks on this sigmoid implementation.
-
-    These checks cannot completely assure the correct implementation of a sigmoid,
-    but try to catch common and obvious mistakes.
-    We recommend to use these for custom sigmoid subclasses.
-
-    The checks are performed on linear spaced stimulus levels between 0 and 1
-    and the provided sigmoid parameters.
-
-    Two checks for relations between parameters:
-      - `sigmoid(threshold_stimulus_level) == threshold_percent_correct`
-      - `|X_L - X_R| == width`
-        with `sigmoid(X_L) == alpha`
-        and  `sigmoid(X_R) == 1 - alpha`
-
-    Two checks for the inverse:
-      - `inverse(PC) == threshold_stimulus_level`
-      - `inverse(inverse(stimulus_levels) == stimulus_levels`
-
-    Two checks for the slope:
-      - `maximum(|slope(stimulus_levels)|)` close to `|slope(0.5)|`
-      - `slope(stimulus_levels) > 0`  (or < 0 for negative sigmoid)
-
-    Args:
-        sigmoid : The Sigmoid subclass to test
-        n_samples: Number of stimulus levels between 0 (exclusive) and 1 for tests
-        threshold: Parameter value for threshold at PC
-        width: Width of the sigmoid
-    Raises:
-        AssertionError if a sanity check fails.
-    """
-    stimulus_levels = np.linspace(-0.3, 1.3, 10000)
-    width = 1 - sigmoid.alpha * 2
-
-    # Test that sigmoid(threshold_stimulus_level) == threshold_percent_correct
-    threshold_stimulus_level = threshold
-    # The threshold passed to the test was computed  by hand to correspond to PC on regular
-    # sigmoids. For negative sigmoids, we'll compare this threshold with the value at 1 - PC.
-    threshold_prop_correct = sigmoid.PC
-    if sigmoid.negative:
-        threshold_prop_correct = 1 - sigmoid.PC
-    prop_correct = sigmoid(threshold_stimulus_level, threshold, width)
-    np.testing.assert_allclose(prop_correct, threshold_prop_correct)
-
-    # Test that the width is equal to the
-    # |X_L - X_R| == WIDTH, with
-    # with sigmoid(X_L) == ALPHA
-    # and  sigmoid(X_R) == 1 - ALPHA
-    prop_correct = sigmoid(stimulus_levels, threshold, width)
-    # When the sigmoid is negative, it is decreasing, so we compute the width on 1-prop_correct
-    # (Alternatively, we could have used `argmax` and swapped the indices)
-    if sigmoid.negative:
-        prop_correct = 1 - prop_correct
-    idx_alpha, idx_nalpha = ((prop_correct < sigmoid.alpha).argmin(),
-                             (prop_correct < (1 - sigmoid.alpha)).argmin())
-    np.testing.assert_allclose(prop_correct[idx_nalpha] - prop_correct[idx_alpha], width,
-                               atol=0.02)
-
-    # Inverse sigmoid at threshold proportion correct (y-axis)
-    # Expects the threshold stimulus level (x-axis).
-    stimulus_level_from_inverse = sigmoid.inverse(threshold_prop_correct,
-                                                  threshold=threshold,
-                                                  width=width)
-    np.testing.assert_allclose(stimulus_level_from_inverse, threshold_stimulus_level)
-
-    # Expects maximal slope at a medium stimulus level
-    slope = sigmoid.slope(stimulus_levels, threshold=threshold, width=width, gamma=0, lambd=0)
-    assert 0.4 * len(slope) < np.argmax(np.abs(slope)) < 0.6 * len(slope)
-    # Expects slope to be all positive/negative for standard/decreasing sigmoid
-    if sigmoid.negative:
-        assert np.all(slope < 0)
-    else:
-        assert np.all(slope > 0)
-
-
 def test_ALL_SIGMOID_NAMES():
     TEST_SIGS = (
         'norm', 'gauss', 'neg_norm', 'neg_gauss', 'logistic', 'neg_logistic',
@@ -104,7 +28,6 @@ def test_sigmoid_by_name(sigmoid_name):
     assert sigmoid_name.startswith('neg_') == s.negative
 
 
-@pytest.mark.skip("still WIP")
 @pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
 def test_sigmoid_sanity_check(sigmoid_name):
     """ Basic sanity checks for sigmoids.
@@ -114,14 +37,14 @@ def test_sigmoid_sanity_check(sigmoid_name):
     of the sigmoid functions.
     """
     # fixed parameters for simple sigmoid sanity checks
-    PC = 0.4
+    PC = 0.45
     # Threshold computed by hand to correspond to PC (for negative sigmoids, we'll compare this
     # threshold with the value at 1 - PC)
-    threshold = 0.460172162722971
+    threshold = 0.54
     alpha = 0.083
 
     sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=alpha)
-    assert_sanity_checks(sigmoid, threshold=threshold)
+    sigmoid.assert_sanity_checks(n_samples=10000, threshold=threshold, width=0.7)
 
 
 @pytest.mark.parametrize(
@@ -143,7 +66,7 @@ def test_sigmoid_values(subclass, expected_y):
 
 
 @pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
-def test_sigmoid_roundtrip(sigmoid_name):
+def test_sigmoid_inverse(sigmoid_name):
     pc = 0.7
     alpha = 0.12
     threshold = 0.6


### PR DESCRIPTION
[updated]

Things that happened in this PR:
- I added tests for all the existing sigmoids that make sure that their implementation is correct. This includes _value, _slope, and _inverse
- I made the sigmoid tests more generic, they were testing always with PC=0.5, alpha=0.05, and threshold=0.5 . These settings do not exercise the code outside of the default values, which is why we missed a problem with negative sigmoids
- I refactored test code (`assert_sanity_checks`) from the class Sigmoid to a standalone function
- The value of Sigmoid.PC now remains consistent even for negative sigmoids, and can be used for plotting and other computations. The _value, _slope, and _inverse method should use Sigmoid._PC, which for negative sigmoid is equal to `1 - PC`
