### PR TITLE
Remove estimate type parameter

### DIFF
--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -1,7 +1,7 @@
 """This module defines the basic configuration object for psignifit.
 """
-import re
 import dataclasses
+import re
 from typing import Any, Dict, Tuple, Optional, Union
 import warnings
 
@@ -32,7 +32,7 @@ class Configuration:
     Note for the developer: if you want to add a new valid option `foobar`,
     expand the `Conf.valid_opts` tuple (in alphabetical order) and add any
     check in a newly defined method `def check_foobar(self, value)`, which
-    raises `PsignifitException` if `value` is outside of the accepted range
+    raises `PsignifitException` if `value` is outside the accepted range
     for `foobar`.
     """
     beta_prior: int = 10

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -38,7 +38,6 @@ class Configuration:
     beta_prior: int = 10
     CI_method: str = 'percentiles'
     confP: Tuple[float, float, float] = (.95, .9, .68)
-    estimate_type: str = 'MAP'
     experiment_type: str = ExperimentType.YES_NO.value
     experiment_choices: Optional[int] = None
     fast_optim: bool = False

--- a/psignifit/demos/demo_001.py
+++ b/psignifit/demos/demo_001.py
@@ -63,17 +63,17 @@ res = ps.psignifit(data, **config)
 #  Yes/No experiments: `experiment_type = 'yes/no'`
 #       A free guessing and lapse rate is estimated
 #  equal asymptote: `experiment_type = 'equal asymptote'`
-#     As Yes/No, but enforces that guessing and lapsing occure equally often
+#     As Yes/No, but enforces that guessing and lapsing occur equally often
 #
 #  Out of the box psignifit supports the following sigmoid functions,
-#  choosen by `sigmoid_name = ...`:
+#  chosen by `sigmoid_name = ...`:
 #
 #  ==================== ================================================
 #  `sigmoid_name = ...` Distribution
 #  ==================== ================================================
-#  'norm'               Cummulative gauss distribution. The default.
+#  'norm'               Cumulative gauss distribution. The default.
 #  'logistic'           Logistic function. Standard alternative.
-#  'gumbel'             Cummulative gumbel distribution.
+#  'gumbel'             Cumulative gumbel distribution.
 #                       Asymmetric, with a longer lower tail.
 #  'rgumbel'            Reversed gumbel distribution. Asymmetric, with a longer upper tail.
 #  'tdist'              Student t-distribution with df=1 for heavy tailed functions.

--- a/psignifit/demos/demo_002.py
+++ b/psignifit/demos/demo_002.py
@@ -42,19 +42,6 @@ res = ps.psignifit(data, **config)
 # a subclass of :class:`psignifit.sigmoids.Sigmoid`.
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# Estimation Type
-# ---------------
-# How you want to estimate your fit from the posterior
-# 'mean' The posterior mean. In a Bayesian sence a more suitable estimate.
-# the expected value of the Posterior.
-# 'MAP' The MAP estimator is the maximum a posteriori computed from
-# the posterior.
-
-config['estimate_type'] = 'MAP'
-config['estimate_type'] = 'mean'
-
-
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Optimization Steps
 # ------------------
 # This sets the number of grid points on each dimension in the final

--- a/psignifit/demos/demo_003.py
+++ b/psignifit/demos/demo_003.py
@@ -24,10 +24,14 @@ res = ps.psignifit(data, sigmoid_name='norm', experiment_type='2AFC')
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# now we can have a look at the res dictionary and all its fields.
+# Now we can have a look at the res dictionary and all its fields.
 #
-# The most important result are the fitted parameters of the psychometric
-# function. They can be found in a dictionary format.
+# The most important result is the Maximum-A-Posteriori (MAP) estimate of the
+# parameters of the psychometric function. The MAP estimate is the value of the
+# parameters that has maximum probability given the observed data and the prior
+# over parameters.
+#
+# The MAP estimate of each parameter is stored in the `parameter_estimate` dictionary.
 
 print(res.parameter_estimate)
 

--- a/psignifit/demos/demo_004.py
+++ b/psignifit/demos/demo_004.py
@@ -146,7 +146,7 @@ ps.psigniplot.plotPsych(res)
 # options['betaPrior']
 # Larger values for this parameter represent a stronger prior, e.g. stronger
 # believe in a stationary observer. Smaller values represent a more
-# conservative inference, giving nonstationary observers a higher prior
+# conservative inference, giving non-stationary observers a higher prior
 # probability.
 # 1 represents a flat prior, e.g. maximally conservative inference. Our
 # default is 10, which fitted our simulations well, around several hundred
@@ -208,7 +208,7 @@ print('Fit with beta prior = 200: ', res200.parameter_estimate)
 # own risk.
 #
 # As an example we will fix the prior on lambda the lapse rate parameter
-# of the psychometric funtion to a constant between 0 and .1 and zero
+# of the psychometric function to a constant between 0 and .1 and zero
 # elsewhere as it was done in the psignifit 2 toolbox.
 #
 # To use custom priors, first define the priors you want to use as function

--- a/psignifit/demos/demo_005.py
+++ b/psignifit/demos/demo_005.py
@@ -31,7 +31,7 @@ res = ps.psignifit(data, sigmoid_name='norm', experiment_type='2AFC')
 # Plot Psychometric Function
 # --------------------------
 #
-# This funciton plots the fitted psychometric function with the measured data.
+# This function plots the fitted psychometric function with the measured data.
 #  It takes the result dict you want to plot. You can also set plotting options.
 #
 # 'dataColor': np.array([0,round(105/255,3),round(170/255,3)]),

--- a/psignifit/demos/demo_006.py
+++ b/psignifit/demos/demo_006.py
@@ -257,8 +257,8 @@ ps.psigniplot.plotsModelfit(res)
 # 1) the psychometric function with the data around it as a first general
 # check.
 # 2) deviance residuals against the stimulus level. This is a check whether
-# the data systematicall lie above or below the psychometric function at a
-# range of stimulus levels. The three lines are polinomials of first
+# the data systematically lie above or below the psychometric function at a
+# range of stimulus levels. The three lines are polynomials of first
 # second and third order fitted to the points. If these dots deviate
 # strongly and/or systematically from 0, this is worrysome. Such deviations
 # indicate that the shape of the psychometric function fitted does not
@@ -282,12 +282,12 @@ resFast = ps.psignifitFast(data, **config)
 #
 #   1) It uses only a binomial model instead of the full beta-binomial model
 #      sacrificing robustness against overdispersion
-#   2) It reduces the number of gridpoints to evaluate the posterior
+#   2) It reduces the number of grid points to evaluate the posterior
 #   3) It limits the number of function evaluations for the final optimization
 #      to find the MAP.
 #
 # Using this function will issue warnings and will not provide you with
 # credible intervals as the grid we use here to evaluate the posterior
 # is probably not dense enough for this type of inference and the
-# beta-binomial model was deactivated. Otherwise the result struct has
+# beta-binomial model was deactivated. Otherwise, the result struct has
 # the same structure as for the full analysis.

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -238,6 +238,7 @@ def _fit_parameters(data: np.ndarray, bounds: ParameterBounds,
     for parm_name, parm_values in grid.items():
         if len(parm_values) == 1:
             fixed_param[parm_name] = parm_values[0]
+    # Compute MAP estimate of parameters on the joint posterior
     fit_dict = maximize_posterior(data, param_init=grid_max, param_fixed=fixed_param, sigmoid=sigmoid, priors=priors)
 
     return fit_dict, posteriors, grid

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -44,7 +44,7 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
     Args:
         data: Trials as described above.
         conf: Optional configuration object.
-        debug: If true, posterior matrix and prior functions will be returned to result object. 
+        debug: If true, posterior matrix and prior functions will be returned to result object.
                In this mode the result object cannot be serialized.
         kwargs: Configurations as function parameters.
     """
@@ -97,7 +97,6 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
 
     if conf.verbose:
         _warn_marginal_sanity_checks(marginals)
-        
 
     if conf.experiment_type == 'equal asymptote':
         fit_dict['gamma'] = fit_dict['lambda'].copy()
@@ -106,7 +105,7 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         marginals['gamma'] = marginals['lambda'].copy()
         # we may want to add a dimension to the posterior array for gamma,
         # which is a copy of the lambda dimension
-        
+
     debug_dict = {}
     if debug:
         debug_dict['posteriors'] = posteriors
@@ -181,7 +180,7 @@ def _warn_marginal_sanity_checks(marginals):
                         'This indicates that your data is not sufficient to exclude higher thresholds than are included in the estimation space.\n'
                         'Either change the prior or ensure that the data is sufficient to constrain the posterior.\n'
                         'Refer to the paper or the manual for more info on this topic.')
-            
+
     if 'width' in marginals:
         width_marginals = marginals['width'] / np.sum(marginals['width'])
         if width_marginals[0] > .001:


### PR DESCRIPTION
First step for #92 : remove `estimate_type` parameter.

It was unused, and it was decided that we will rather *add* other types of parameter estimates to the Results object, rather than offering the estimates as alternative running modes.

The first commit removes the parameter, the second fixes typos I found while reading the demos