### PR TITLE
Save confidence intervals as a dictionary

### DIFF
--- a/docs/examples/demo_002.md
+++ b/docs/examples/demo_002.md
@@ -114,13 +114,6 @@ config['confP'] = [.95, .9, .68, .5]
 `CI_method` sets how the confidence intervals are computed in getConfRegion
 possible variants are:
 
-'stripes': Find a threshold with (1-alpha) above it
-     This will disregard intervals of low posterior probability and then move
-     in from the sides to adjust the exact CI size.
-     This can handle bounds and asymmetric distributions slightly better, but
-     will introduce slight jumps of the confidence interval when confp is
-     adjusted depending on when the gridpoints get too small posterior
-     probability.
 'project':
      Project the confidence region on each axis
 'percentiles': find alpha/2 and 1-alpha/2 percentiles (alpha = 1-confP)

--- a/psignifit/_confidence.py
+++ b/psignifit/_confidence.py
@@ -3,18 +3,18 @@
 Confidence intervals and region for parameters
 
 Two methods are implemented:
-      'project' -> project the confidence region down each axis
+  'project' -> project the confidence region down each axis
   'percentiles' -> find alpha/2 and 1-alpha/2 percentiles
                    (alpha = 1-confP)
 """
-from typing import Sequence
+from typing import Dict, Sequence
 
 import numpy as np
 from scipy import stats
 
 
 def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
-                         p_values: Sequence[float], mode: str) -> np.ndarray:
+                         p_values: Sequence[float], mode: str) -> Dict[str, np.ndarray]:
     """ Confidence intervals on probability grid.
 
     Supports two methods:
@@ -31,8 +31,8 @@ def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
         p_values: Probabilities of confidence in the intervals.
         mode: Either 'project' or 'percentiles'.
     Returns:
-        Start and end grid-values for the confidence interval
-        per dimension and p_value, shape (n_dims, n_p_values, 2)
+        A dictionary mapping p_values as a string to an array containing the start and end grid-values for the
+        confidence interval per dimension, shape (n_dims, 2).
     Raises:
         ValueError for unsupported mode or sum(probability_mass) != 1.
      """
@@ -44,9 +44,9 @@ def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
 
     if not np.isclose(probability_mass.sum(), 1):
         raise ValueError(f'Expects sum(probability_mass) to be 1., got {probability_mass.sum():.4f}')
-    intervals = np.empty((probability_mass.ndim, len(p_values), 2))
-    for p_ix, p_value in enumerate(p_values):
-        intervals[:, p_ix, :] = calc_ci(probability_mass, grid_values, p_value)
+    intervals = {}
+    for p_value in p_values:
+        intervals[str(p_value)] = calc_ci(probability_mass, grid_values, p_value)
 
     return intervals
 

--- a/psignifit/_confidence.py
+++ b/psignifit/_confidence.py
@@ -14,7 +14,7 @@ from scipy import stats
 
 
 def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
-                         p_values: Sequence[float], mode: str) -> Dict[str, np.ndarray]:
+                         p_values: Sequence[float], mode: str) -> Dict[str, list]:
     """ Confidence intervals on probability grid.
 
     Supports two methods:
@@ -31,7 +31,7 @@ def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
         p_values: Probabilities of confidence in the intervals.
         mode: Either 'project' or 'percentiles'.
     Returns:
-        A dictionary mapping p_values as a string to an array containing the start and end grid-values for the
+        A dictionary mapping p_values as a string to a list containing the start and end grid-values for the
         confidence interval per dimension, shape (n_dims, 2).
     Raises:
         ValueError for unsupported mode or sum(probability_mass) != 1.
@@ -46,7 +46,7 @@ def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
         raise ValueError(f'Expects sum(probability_mass) to be 1., got {probability_mass.sum():.4f}')
     intervals = {}
     for p_value in p_values:
-        intervals[str(p_value)] = calc_ci(probability_mass, grid_values, p_value)
+        intervals[str(p_value)] = calc_ci(probability_mass, grid_values, p_value).tolist()
 
     return intervals
 

--- a/psignifit/_confidence.py
+++ b/psignifit/_confidence.py
@@ -39,9 +39,6 @@ def confidence_intervals(probability_mass: np.ndarray, grid_values: np.ndarray,
     CI_METHODS = {'project': grid_hdi, 'percentiles': percentile_intervals}
     if mode in CI_METHODS:
         calc_ci = CI_METHODS[mode]
-    elif mode == 'stripes':
-        raise ValueError('Confidence mode "stripes" is not supported anymore. "'
-                         f'"Use one of {list(CI_METHODS.keys())}.')
     else:
         raise ValueError(f'Expects mode as one of {list(CI_METHODS.keys())}, got {mode}')
 

--- a/psignifit/demos/demo_002.py
+++ b/psignifit/demos/demo_002.py
@@ -82,13 +82,6 @@ config['confP'] = [.95, .9, .68, .5]
 # `CI_method` sets how the confidence intervals are computed in getConfRegion
 # possible variants are:
 #
-# 'stripes': Find a threshold with (1-alpha) above it
-#      This will disregard intervals of low posterior probability and then move
-#      in from the sides to adjust the exact CI size.
-#      This can handle bounds and asymmetric distributions slightly better, but
-#      will introduce slight jumps of the confidence interval when confp is
-#      adjusted depending on when the gridpoints get too small posterior
-#      probability.
 # 'project':
 #      Project the confidence region on each axis
 # 'percentiles': find alpha/2 and 1-alpha/2 percentiles (alpha = 1-confP)

--- a/psignifit/demos/demo_002.py
+++ b/psignifit/demos/demo_002.py
@@ -62,20 +62,13 @@ config['grid_steps'] = {'lambda': 50}
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Confidence intervals
 # --------------------
-# The confidence level for the computed confidence intervals.
-# This may be set to any number between 0 and 1 excluding.
+# A tuple of confidence levels for the computed confidence intervals.
+# Each confidence level is specified as a number between 0 and 1, excluded.
+# Note that some plotting utilities rely on 0.95 being one of the confidence
+# levels, so you may want to include it in there.
 
-# for example to get 99% confidence intervals try
-config['confP'] = .99
-
-# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# You may specify a vector with N elements as well.
-# If you do the conf_intervals in the
-# result will be a 5x2xN array containing the values for the different
-# confidence levels in the 3rd dimension.
-
-# will return 4 confidence intervals for each parameter for example.
-config['confP'] = [.95, .9, .68, .5]
+# for example to get 95%, 99%, and 31% confidence intervals try
+config['confP'] = (0.95, 0.99, 0.31)
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -91,8 +91,9 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
 
     grid_values = [grid_value for _, grid_value in sorted(grid.items())]
     intervals = confidence_intervals(posteriors, grid_values, conf.confP, conf.CI_method)
-    intervals_dict = {param: interval_per_p.tolist()
-                      for param, interval_per_p in zip(sorted(grid.keys()), intervals)}
+    intervals_dict = {}
+    for idx, param in enumerate(sorted(grid.keys())):
+        intervals_dict[param] = {k: v[idx] for k, v in intervals.items()}
     marginals = marginalize_posterior(grid, posteriors)
 
     if conf.verbose:

--- a/psignifit/psigniplot.py
+++ b/psignifit/psigniplot.py
@@ -69,11 +69,11 @@ def plot_psychometric_function(result: Result,  # noqa: C901, this function is t
         ax.axhline(y=1 - params['lambda'], linestyle=':', color=line_color)
         ax.axhline(y=params['gamma'], linestyle=':', color=line_color)
 
-        CI = np.asarray(result.confidence_intervals['threshold'])
+        CI_95 = result.confidence_intervals['threshold']['0.95']
         y = np.array([params['gamma'] + .5 * (1 - params['lambda'] - params['gamma'])] * 2)
-        ax.plot(CI[0, :], y, c=line_color)
-        ax.plot([CI[0, 0]] * 2, y + [-.01, .01], c=line_color)
-        ax.plot([CI[0, 1]] * 2, y + [-.01, .01], c=line_color)
+        ax.plot(CI_95, y, c=line_color)
+        ax.plot([CI_95[0]] * 2, y + [-.01, .01], c=line_color)
+        ax.plot([CI_95[1]] * 2, y + [-.01, .01], c=line_color)
 
     # AXIS SETTINGS
     plt.axis('tight')
@@ -231,8 +231,8 @@ def plot_marginal(result: Result,
     x = np.asarray(result.parameter_values[parameter])
     xmin, xmax = x.min(), x.max()
     if plot_estimate:
-        # takes first confidence interval from the list
-        CI= np.asarray(result.confidence_intervals[parameter][0])
+        # takes 95% confidence interval
+        CI = result.confidence_intervals[parameter]['0.95']
         ci_x = np.r_[CI[0], x[(x >= CI[0]) & (x <= CI[1])], CI[1]]
         ax.fill_between(ci_x, np.zeros_like(ci_x), np.interp(ci_x, x, marginal), color=line_color, alpha=0.5)
 

--- a/psignifit/tests/test_confidence.py
+++ b/psignifit/tests/test_confidence.py
@@ -47,9 +47,12 @@ def test_confidence_intervals(zerocentered_normal_mass, grid_values):
     p_values = [0.05, 0.5, 0.95]
 
     intervals = confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='project')
-    assert intervals.shape == (len(grid_values), len(p_values), 2)
+    assert list(intervals.keys()) == [str(p) for p in p_values]
+    assert all(interval.shape == (len(grid_values), 2) for interval in intervals.values())
+
     intervals = confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='percentiles')
-    assert intervals.shape == (len(grid_values), len(p_values), 2)
+    assert list(intervals.keys()) == [str(p) for p in p_values]
+    assert all(interval.shape == (len(grid_values), 2) for interval in intervals.values())
 
     with pytest.raises(ValueError):
         confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='foobar')

--- a/psignifit/tests/test_confidence.py
+++ b/psignifit/tests/test_confidence.py
@@ -48,11 +48,11 @@ def test_confidence_intervals(zerocentered_normal_mass, grid_values):
 
     intervals = confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='project')
     assert list(intervals.keys()) == [str(p) for p in p_values]
-    assert all(interval.shape == (len(grid_values), 2) for interval in intervals.values())
+    assert all(len(interval) == len(grid_values) for interval in intervals.values())
 
     intervals = confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='percentiles')
     assert list(intervals.keys()) == [str(p) for p in p_values]
-    assert all(interval.shape == (len(grid_values), 2) for interval in intervals.values())
+    assert all(len(interval) == len(grid_values) for interval in intervals.values())
 
     with pytest.raises(ValueError):
         confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='foobar')

--- a/psignifit/tests/test_confidence.py
+++ b/psignifit/tests/test_confidence.py
@@ -52,8 +52,6 @@ def test_confidence_intervals(zerocentered_normal_mass, grid_values):
     assert intervals.shape == (len(grid_values), len(p_values), 2)
 
     with pytest.raises(ValueError):
-        confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='stripes')
-    with pytest.raises(ValueError):
         confidence_intervals(zerocentered_normal_mass, grid_values, p_values, mode='foobar')
     with pytest.raises(ValueError):
         confidence_intervals(zerocentered_normal_mass * 3, grid_values, p_values, mode='project')


### PR DESCRIPTION
Fix #136 
Fix #142 

Confidence intervals are not saved as 
```
>>> result.confidence_intervals['threshold'] 
{
 '0.95' : [0.0041551724137931035, 0.005110079575596817],
 '0.9' : [0.004218832891246685, 0.005110079575596817],
 '0.68' : [0.004346153846153846, 0.004982758620689655]
}
```

I propose to use '0.95' instead of '95%', because in my experience the latter would mean that we'll be writing forever code that converts '95%' into 0.95 and viceversa