### PR TITLE
Fix computation of confidence interval `Result.threshold` method

### DIFF
--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -126,18 +126,21 @@ class Result:
         if not return_ci:
             return new_threshold
 
-        param_cis = [self.confidence_intervals[param] for param in ('threshold', 'width', 'lambda', 'gamma')]
-        if unscaled:  # set asymptotes to 0
-            param_cis[2] = np.zeros_like(param_cis[2])
-            param_cis[3] = np.zeros_like(param_cis[3])
-
-        new_ci = []
-        for (thres_ci, width_ci, lambd_ci, gamma_ci) in zip(*param_cis):
+        new_threshold_ci = {}
+        for coverage_key in self.confidence_intervals['threshold'].keys():
+            thres_ci = self.confidence_intervals['threshold'][coverage_key]
+            width_ci = self.confidence_intervals['width'][coverage_key]
+            if unscaled:
+                gamma_ci = np.array([0.0, 0.0])
+                lambd_ci = np.array([0.0, 0.0])
+            else:
+                gamma_ci = self.confidence_intervals['gamma'][coverage_key]
+                lambd_ci = self.confidence_intervals['lambda'][coverage_key]
             ci_min = sigmoid.inverse(proportion_correct, thres_ci[0], width_ci[0], gamma_ci[0], lambd_ci[0])
             ci_max = sigmoid.inverse(proportion_correct, thres_ci[1], width_ci[1], gamma_ci[1], lambd_ci[1])
-            new_ci.append([ci_min, ci_max])
+            new_threshold_ci[coverage_key] = [ci_min, ci_max]
 
-        return new_threshold, new_ci
+        return new_threshold, new_threshold_ci
 
     def slope(self, stimulus_level: np.ndarray, estimate_type: Optional[EstimateType]=None) -> np.ndarray:
         """ Slope of the psychometric function at a given stimulus levels.

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -121,12 +121,19 @@ def test_threshold_value():
     result = _build_result(parameter_estimate, parameter_estimate, confidence_intervals)
 
     # The threshold at the middle of the gamma-to-(1-lambda) range must be 0.5 for a Gaussian
-    thr, thr_ci = result.threshold(
+    thr = result.threshold(
         proportion_correct=np.array([(1 - lambda_ - gamma) / 2.0 + gamma]),
-        unscaled=False, return_ci=True,
+        unscaled=False, return_ci=False,
     )
+    expected_thr = np.array(0.5)  # by construction
+    np.testing.assert_allclose(thr, expected_thr)
 
-    expected_thr = np.array(0.5)
+    # ... except when unscaled is True
+    thr = result.threshold(
+        proportion_correct=np.array([(1 - lambda_ - gamma) / 2.0 + gamma]),
+        unscaled=True, return_ci=False,
+    )
+    expected_thr = np.array([0.5343785])  # computed by hand
     np.testing.assert_allclose(thr, expected_thr)
 
     # Compare to results computed by hand


### PR DESCRIPTION
It had not been updated to the new format of the confidence interval dictionary: `{'0.95': [ci_min, ci_max], '0.9': ...}`


Fix #172

