### PR TITLE
Reinstate `Result.parameter_estimate`

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -112,7 +112,7 @@ and the confidence intervals:
 jupyter:
   outputs_hidden: False
 ---
-print(result.get_parameters_estimate())
+print(result.parameter_estimate)
 ```
 
 This returns a python dictionary containing the estimated parameters.
@@ -132,7 +132,7 @@ The parameters estimated by psignifit are:
 Then, to obtain the threhsold you run
 
 ```{code-cell} ipython3
-print(result.get_parameters_estimate()['threshold'])
+print(result.parameter_estimate['threshold'])
 ```
 
 

--- a/docs/examples/parameter_recovery_demo.md
+++ b/docs/examples/parameter_recovery_demo.md
@@ -142,7 +142,7 @@ res = psignifit.psignifit(data, **options)
 
 +++ {"nteract": {"transient": {"deleting": false}}}
 
-Lastly, we can ensure that the values in our `res.get_parameters_estimate()` dictionary are equal to the values that we used to simulate them
+Lastly, we can ensure that the values in our `res.parameter_estimate` dictionary are equal to the values that we used to simulate them
 
 ```{code-cell} ipython3
 ---
@@ -150,7 +150,7 @@ nteract:
   transient:
     deleting: false
 ---
-assert np.isclose(res.get_parameters_estimate()['lambda'], lambda_, atol=1e-2)
+assert np.isclose(res.parameter_estimate['lambda'], lambda_, atol=1e-2)
 ```
 
 ```{code-cell} ipython3
@@ -159,7 +159,7 @@ nteract:
   transient:
     deleting: false
 ---
-assert np.isclose(res.get_parameters_estimate()['gamma'], gamma, atol=1e-2)
+assert np.isclose(res.parameter_estimate['gamma'], gamma, atol=1e-2)
 ```
 
 ```{code-cell} ipython3
@@ -168,9 +168,9 @@ nteract:
   transient:
     deleting: false
 ---
-assert np.isclose(res.get_parameters_estimate()['eta'], 0, atol=1e-2)
-assert np.isclose(res.get_parameters_estimate()['threshold'], threshold, atol=1e-2)
-assert np.isclose(res.get_parameters_estimate()['width'], width, atol=1e-2)
+assert np.isclose(res.parameter_estimate['eta'], 0, atol=1e-2)
+assert np.isclose(res.parameter_estimate['threshold'], threshold, atol=1e-2)
+assert np.isclose(res.parameter_estimate['width'], width, atol=1e-2)
 ```
 
 ```{code-cell} ipython3

--- a/docs/examples/priors.md
+++ b/docs/examples/priors.md
@@ -191,7 +191,7 @@ res = ps.psignifit(data, experiment_type='2AFC')
 First lets have a look at the results with the standard prior strength:
 
 ```{code-cell} ipython3
-print('Fit:', res.get_parameters_estimate())
+print('Fit:', res.parameter_estimate)
 print('confidence Intervals:', res.confidence_intervals)
 ```
 
@@ -211,8 +211,8 @@ First see that the only parameter whose fit changes by this is the
 beta-variance parameter eta (the 5th)
 
 ```{code-cell} ipython3
-print('Fit with beta prior = 1: ', res1.get_parameters_estimate())
-print('Fit with beta prior = 200: ', res200.get_parameters_estimate())
+print('Fit with beta prior = 1: ', res1.parameter_estimate)
+print('Fit with beta prior = 200: ', res200.parameter_estimate)
 ```
 
 Now we have a look at the confidence intervals

--- a/docs/examples/results-object.md
+++ b/docs/examples/results-object.md
@@ -42,7 +42,7 @@ The most important result are the fitted parameters of the psychometric
 function. They can be found in a dictionary format.
 
 ```{code-cell} ipython3
-print(res.get_parameters_estimate())
+print(res.parameter_estimate)
 ```
 
 For each of these parameters, also the confidence interval is contained
@@ -77,7 +77,7 @@ otherdata[:, 0] = otherdata[:, 0] + 0.01
 other_res = ps.psignifit(otherdata, res.configuration)
 
 # the difference in threshold should return the introduced shift
-print(other_res.get_parameters_estimate()['threshold'] - res.get_parameters_estimate()['threshold'])
+print(other_res.parameter_estimate['threshold'] - res.parameter_estimate['threshold'])
 ```
 
 ## Saving to JSON
@@ -94,7 +94,7 @@ It can be loaded again to be used at a later time, for example for plotting
 
 ```{code-cell} ipython3
 loaded_res = ps.Result.load_json(file_name)
-print(loaded_res.get_parameters_estimate())
+print(loaded_res.parameter_estimate)
 ```
 
 ```{code-cell} ipython3

--- a/docs/how_to/How-to-Fix-Parameters.md
+++ b/docs/how_to/How-to-Fix-Parameters.md
@@ -51,6 +51,6 @@ res = ps.psignifit(data, **options)
 We print the parameter estimates to check that lambda was indeed fixed
 
 ```{code-cell} ipython3
-print(res.get_parameters_estimate())
+print(res.parameter_estimate)
 ```
 

--- a/docs/how_to/How-to-Get-Thresholds-and-Slopes.md
+++ b/docs/how_to/How-to-Get-Thresholds-and-Slopes.md
@@ -70,7 +70,7 @@ res.threshold(0.5, unscaled=True)
 which should be 0.0046, which is exactly the definition of the threshold we use in the fitting.
 
 ```{code-cell} ipython3
-res.get_parameters_estimate()['threshold']
+res.parameter_estimate['threshold']
 ```
 
 The function also returns worst-case credible intervals for the

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -19,8 +19,8 @@ class NumpyEncoder(json.JSONEncoder):
 
 @dataclasses.dataclass
 class Result:
-    parameters_estimate_MAP: Dict[str, float]
-    parameters_estimate_mean: Dict[str, float]
+    parameter_estimate_MAP: Dict[str, float]
+    parameter_estimate_mean: Dict[str, float]
     configuration: Configuration
     confidence_intervals: Dict[str, List[Tuple[float, float]]]
     data: NDArray[float]
@@ -68,7 +68,7 @@ class Result:
         result_dict['data'] = np.asarray(result_dict['data'])
         return cls.from_dict(result_dict)
 
-    def get_parameters_estimate(self, estimate_type: Optional[EstimateType]=None):
+    def get_parameter_estimate(self, estimate_type: Optional[EstimateType]=None):
         """ Get the estimate of the parameters by type.
 
         Args:
@@ -81,9 +81,9 @@ class Result:
             estimate_type = self.configuration.estimate_type
 
         if estimate_type == 'MAP':
-            estimate = self.parameters_estimate_MAP
+            estimate = self.parameter_estimate_MAP
         elif estimate_type == 'mean':
-            estimate = self.parameters_estimate_mean
+            estimate = self.parameter_estimate_mean
         else:
             raise ValueError("`estimate_type` must be either 'MAP' or 'mean'")
 
@@ -116,7 +116,7 @@ class Result:
         proportion_correct = np.asarray(proportion_correct)
         sigmoid = self.configuration.make_sigmoid()
 
-        estimate = self.get_parameters_estimate(estimate_type)
+        estimate = self.get_parameter_estimate(estimate_type)
         if unscaled:  # set asymptotes to 0 for everything.
             lambd, gamma = 0, 0
         else:
@@ -152,7 +152,7 @@ class Result:
         Returns:
             Slopes of the psychometric function at the stimulus levels.
         """
-        stimulus_level, param = np.asarray(stimulus_level), self.get_parameters_estimate(estimate_type)
+        stimulus_level, param = np.asarray(stimulus_level), self.get_parameter_estimate(estimate_type)
         sigmoid = self.configuration.make_sigmoid()
         return sigmoid.slope(stimulus_level, param['threshold'], param['width'], param['gamma'], param['lambda'])
 
@@ -174,7 +174,7 @@ class Result:
         stimulus_levels = self.threshold(proportion_correct, unscaled, return_ci=False, estimate_type=estimate_type)
         return self.slope(stimulus_levels)
 
-    def standard_parameters_estimate(self, estimate_type: Optional[EstimateType]=None):
+    def standard_parameter_estimate(self, estimate_type: Optional[EstimateType]=None):
         """ Get the parameters of the psychometric function in the standard format.
 
         `psignifit` uses the same intuitive parametrization, threshold and width, for all
@@ -192,6 +192,6 @@ class Result:
             Standard parameters (loc, scale) for the sigmoid subclass.
         """
         sigmoid = self.configuration.make_sigmoid()
-        estimate = self.get_parameters_estimate(estimate_type)
+        estimate = self.get_parameter_estimate(estimate_type)
         loc, scale = sigmoid.standard_parameters(estimate['threshold'], estimate['width'])
         return loc, scale

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -89,6 +89,8 @@ class Result:
 
         return estimate
 
+    parameter_estimate = property(get_parameter_estimate)
+
     def threshold(self, proportion_correct: np.ndarray, unscaled: bool = False, return_ci: bool = True,
                   estimate_type: Optional[EstimateType]=None) -> Union[np.ndarray, List[Tuple[np.ndarray, np.ndarray]]]:
         """ Threshold stimulus value and confidence interval for a different proportion correct cutoff.

--- a/psignifit/demos/parameters_estimates.ipynb
+++ b/psignifit/demos/parameters_estimates.ipynb
@@ -309,7 +309,7 @@
    ],
    "source": [
     "# This gives the default estimate, in this case the mean estimate since we set it in the options.\n",
-    "result.get_parameter_estimate()  "
+    "result.parameter_estimate  "
    ]
   },
   {
@@ -333,8 +333,8 @@
     }
    ],
    "source": [
-    "# We can overwrite the default setting by specifying the `estimate_type` parameter\n",
-    "result.get_parametersestimate(estimate_type='MAP')  "
+    "# We can overwrite the default setting by specifying the `estimate_type` parameter in the method get_parameter_estimate\n",
+    "result.get_parameter_estimate(estimate_type='MAP')  "
    ]
   },
   {
@@ -468,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   },
   "nteract": {
    "version": "0.28.0"

--- a/psignifit/demos/parameters_estimates.ipynb
+++ b/psignifit/demos/parameters_estimates.ipynb
@@ -147,7 +147,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false,
      "source_hidden": false
@@ -310,7 +309,7 @@
    ],
    "source": [
     "# This gives the default estimate, in this case the mean estimate since we set it in the options.\n",
-    "result.get_parameters_estimate()  "
+    "result.get_parameter_estimate()  "
    ]
   },
   {
@@ -335,7 +334,7 @@
    ],
    "source": [
     "# We can overwrite the default setting by specifying the `estimate_type` parameter\n",
-    "result.get_parameters_estimate(estimate_type='MAP')  "
+    "result.get_parametersestimate(estimate_type='MAP')  "
    ]
   },
   {
@@ -469,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.12.7"
   },
   "nteract": {
    "version": "0.28.0"

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -115,8 +115,8 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         debug_dict['priors'] = priors
         debug_dict['bounds'] = bounds
 
-    return Result(parameters_estimate_MAP=estimate_MAP_dict,
-                  parameters_estimate_mean=estimate_mean_dict,
+    return Result(parameter_estimate_MAP=estimate_MAP_dict,
+                  parameter_estimate_mean=estimate_mean_dict,
                   configuration=conf,
                   confidence_intervals=intervals_dict,
                   parameter_values=grid,

--- a/psignifit/psigniplot.py
+++ b/psignifit/psigniplot.py
@@ -28,7 +28,7 @@ def plot_psychometric_function(result: Result,  # noqa: C901, this function is t
     if ax is None:
         ax = plt.gca()
 
-    params = result.get_parameters_estimate(estimate_type=estimate_type)
+    params = result.get_parameter_estimate(estimate_type=estimate_type)
     data = np.asarray(result.data)
     config = result.configuration
 
@@ -106,7 +106,7 @@ def _plot_residuals(x_values: np.ndarray,
                     estimate_type: EstimateType = None):
     if ax is None:
         ax = plt.gca()
-    params = result.get_parameters_estimate(estimate_type=estimate_type)
+    params = result.get_parameter_estimate(estimate_type=estimate_type)
     data = result.data
     sigmoid = result.configuration.make_sigmoid()
 
@@ -245,7 +245,7 @@ def plot_marginal(result: Result,
         ci_x = np.r_[CI[0], x[(x >= CI[0]) & (x <= CI[1])], CI[1]]
         ax.fill_between(ci_x, np.zeros_like(ci_x), np.interp(ci_x, x, marginal), color=line_color, alpha=0.5)
 
-        estimate = result.get_parameters_estimate(estimate_type=estimate_type)
+        estimate = result.get_parameter_estimate(estimate_type=estimate_type)
         param_value = estimate[parameter]
         ax.plot([param_value] * 2, [0, np.interp(param_value, x, marginal)], color='#000000')
 
@@ -306,7 +306,7 @@ def plot_prior(result: Result,
 
     data = result.data
     bounds = result.debug['bounds']
-    estimate = result.get_parameters_estimate(estimate_type=estimate_type)
+    estimate = result.get_parameter_estimate(estimate_type=estimate_type)
     sigmoid = result.configuration.make_sigmoid()
 
     sigmoid_x = np.linspace(bounds['threshold'][0], bounds['threshold'][1], 1000)
@@ -369,8 +369,8 @@ def plot_2D_margin(result: Result,
     if result.debug=={}:
         raise ValueError("Expects priors and marginals saved. Try running psignifit(....., debug=True).")
 
-    parameters_keys = result.parameters_estimate_MAP.keys()
-    parameter_indices = {param: i for i, param in enumerate(sorted(parameters_keys))}
+    parameter_keys = result.parameter_estimate_MAP.keys()
+    parameter_indices = {param: i for i, param in enumerate(sorted(parameter_keys))}
     other_param_ix = tuple(i for param, i in parameter_indices.items()
                            if param != first_param and param != second_param)
     marginal_2d = np.sum(result.debug['posteriors'], axis=other_param_ix)

--- a/psignifit/tests/test_basic.py
+++ b/psignifit/tests/test_basic.py
@@ -29,7 +29,7 @@ def get_std_options():
 def test_fit_basic(data):
     options = get_std_options()
     res = psignifit(data, **options)
-    param = res.parameters_estimate_MAP
+    param = res.parameter_estimate_MAP
     assert isclose(param['threshold'], 0.0046, abs_tol=0.0001)
     assert isclose(param['width'], 0.0045, abs_tol=0.0001)
     assert isclose(param['lambda'], 0.01, abs_tol=0.0001)
@@ -80,7 +80,7 @@ def test_bias_analysis(data):
 def test_fixed_parameters(data):
     options = get_std_options()
     res = psignifit(data, **options)
-    estim_param = res.parameters_estimate_MAP
+    estim_param = res.parameter_estimate_MAP
     fixed_param = res.configuration.fixed_parameters
     all_param_values = res.parameter_values
 

--- a/psignifit/tests/test_param_recovery.py
+++ b/psignifit/tests/test_param_recovery.py
@@ -32,11 +32,11 @@ def test_parameter_recovery_2afc(sigmoid):
 
     res = psignifit(data, **options)
 
-    assert np.isclose(res.parameters_estimate_MAP['lambda'], lambda_)
-    assert np.isclose(res.parameters_estimate_MAP['gamma'], gamma)
-    assert np.isclose(res.parameters_estimate_MAP['eta'], 0, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['threshold'], threshold, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['width'], width, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['lambda'], lambda_)
+    assert np.isclose(res.parameter_estimate_MAP['gamma'], gamma)
+    assert np.isclose(res.parameter_estimate_MAP['eta'], 0, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['threshold'], threshold, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['width'], width, atol=1e-4)
 
 
 @pytest.mark.parametrize("eta", [0.1, 0.2, 0.3])
@@ -66,11 +66,11 @@ def test_parameter_recovery_2afc_eta(random_state, eta):
 
     res = psignifit(data, **options)
 
-    assert np.isclose(res.parameters_estimate_MAP['lambda'], lambda_)
-    assert np.isclose(res.parameters_estimate_MAP['gamma'], gamma)
-    assert np.isclose(res.parameters_estimate_MAP['eta'], eta, atol=0.05)
-    assert np.isclose(res.parameters_estimate_MAP['threshold'], threshold, atol=0.01)
-    assert np.isclose(res.parameters_estimate_MAP['width'], width, atol=0.05)
+    assert np.isclose(res.parameter_estimate_MAP['lambda'], lambda_)
+    assert np.isclose(res.parameter_estimate_MAP['gamma'], gamma)
+    assert np.isclose(res.parameter_estimate_MAP['eta'], eta, atol=0.05)
+    assert np.isclose(res.parameter_estimate_MAP['threshold'], threshold, atol=0.01)
+    assert np.isclose(res.parameter_estimate_MAP['width'], width, atol=0.05)
 
 
 # threshold and width can not be fixed.
@@ -112,11 +112,11 @@ def test_parameter_recovery_fixed_params(fixed_param):
 
     res = psignifit(data, **options)
     # check fixed params are not touched
-    assert res.parameters_estimate_MAP[fixed_param] == sim_params[fixed_param]
+    assert res.parameter_estimate_MAP[fixed_param] == sim_params[fixed_param]
 
     for p in ['lambda', 'gamma', 'threshold', 'width', 'eta']:
         # check all other params are estimated correctly
-        assert np.isclose(res.parameters_estimate_MAP[p], sim_params[p], rtol=1e-4, atol=1 / 40), f"failed for parameter {p} for estimation with fixed: {fixed_param}."
+        assert np.isclose(res.parameter_estimate_MAP[p], sim_params[p], rtol=1e-4, atol=1 / 40), f"failed for parameter {p} for estimation with fixed: {fixed_param}."
 
 
 @pytest.mark.parametrize("sigmoid", list(ALL_SIGMOID_NAMES))
@@ -144,11 +144,11 @@ def test_parameter_recovery_YN(sigmoid):
 
     res = psignifit(data, **options)
 
-    assert np.isclose(res.parameters_estimate_MAP['lambda'], lambda_, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['gamma'], gamma, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['eta'], 0, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['threshold'], threshold, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['width'], width, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['lambda'], lambda_, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['gamma'], gamma, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['eta'], 0, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['threshold'], threshold, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['width'], width, atol=1e-4)
 
 
 @pytest.mark.parametrize("sigmoid", list(ALL_SIGMOID_NAMES))
@@ -176,11 +176,11 @@ def test_parameter_recovery_eq_asymptote(sigmoid):
 
     res = psignifit(data, **options)
 
-    assert np.isclose(res.parameters_estimate_MAP['lambda'], lambda_, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['gamma'], gamma, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['eta'], 0, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['threshold'], threshold, atol=1e-4)
-    assert np.isclose(res.parameters_estimate_MAP['width'], width, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['lambda'], lambda_, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['gamma'], gamma, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['eta'], 0, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['threshold'], threshold, atol=1e-4)
+    assert np.isclose(res.parameter_estimate_MAP['width'], width, atol=1e-4)
 
 
 @fp_error_handler(over='ignore', invalid='ignore')
@@ -219,7 +219,7 @@ def test_parameter_recovery_mean_estimate(random_state):
          'width': width,
     }
     for p in expected_mean_dict.keys():
-        assert np.isclose(result.parameters_estimate_mean[p], expected_mean_dict[p], atol=0.05)
+        assert np.isclose(result.parameter_estimate_mean[p], expected_mean_dict[p], atol=0.05)
 
 
 @fp_error_handler(over='ignore', invalid='ignore')
@@ -274,7 +274,7 @@ def test_mean_vs_map_estimate(random_state):
          'width': 3.679911898980962,
     }
     for p in expected_MAP_dict.keys():
-        assert np.isclose(result.parameters_estimate_MAP[p], expected_MAP_dict[p])
+        assert np.isclose(result.parameter_estimate_MAP[p], expected_MAP_dict[p])
 
     expected_mean_dict = {
         'eta': 0.07274831038039509,
@@ -284,4 +284,4 @@ def test_mean_vs_map_estimate(random_state):
         'width': 4.027280086833293,
     }
     for p in expected_mean_dict.keys():
-        assert np.isclose(result.parameters_estimate_mean[p], expected_mean_dict[p])
+        assert np.isclose(result.parameter_estimate_mean[p], expected_mean_dict[p])

--- a/psignifit/tests/test_psignifit.py
+++ b/psignifit/tests/test_psignifit.py
@@ -25,7 +25,7 @@ def test_psignifit_fixed_fit():
                   'eta': 0.00011599137494786461}
 
     results = psignifit(DATA, sigmoid='norm', experiment_type='2AFC')
-    parm = results.get_parameters_estimate(estimate_type='MAP')
+    parm = results.get_parameter_estimate(estimate_type='MAP')
 
     for p in parm:
         np.testing.assert_allclose(parm[p], parm_heiko[p], rtol=1e-4, atol=1e-4)

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -200,7 +200,7 @@ def _close_numpy_dict(first, second):
     """ Test if two dicts of numpy arrays are equal"""
     if first.keys() != second.keys():
         return False
-    return np.all(np.isclose(first[key], second[key]) for key in first)
+    return np.all([np.all(np.isclose(first[key], second[key])) for key in first])
 
 
 def test_save_load_result_json(result, tmp_path):

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -202,6 +202,11 @@ def _close_numpy_dict(first, second):
         return False
     return np.all([np.all(np.isclose(first[key], second[key])) for key in first])
 
+def _equal_numpy_dict(first, second):
+    """ Test if two dicts of numpy arrays are equal"""
+    if first.keys() != second.keys():
+        return False
+    return np.all([np.all(first[key] == second[key]) for key in first])
 
 def test_save_load_result_json(result, tmp_path):
     result_file = tmp_path / 'result.json'

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -239,8 +239,14 @@ def test_get_parameter_estimate(result):
 
 def test_parameter_estimate_property(result):
     estimate = result.parameter_estimate
+    # verify that we get the parameter estimate MAP by default
     assert _equal_numpy_dict(estimate, result.parameter_estimate_MAP)
     assert not _equal_numpy_dict(estimate, result.parameter_estimate_mean)
+    # verify that we get the mean parameter estimate if we change the estimate type
+    result.configuration.estimate_type = 'mean'
+    estimate = result.parameter_estimate
+    assert not _equal_numpy_dict(estimate, result.parameter_estimate_MAP)
+    assert _equal_numpy_dict(estimate, result.parameter_estimate_mean)
 
 def test_estimate_type_default(result):
     result.configuration.estimate_type = 'MAP'

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -237,6 +237,10 @@ def test_get_parameter_estimate(result):
     with pytest.raises(ValueError):
         result.get_parameter_estimate(estimate_type='foo')
 
+def test_parameter_estimate_property(result):
+    estimate = result.parameter_estimate
+    assert _equal_numpy_dict(estimate, result.parameter_estimate_MAP)
+    assert not _equal_numpy_dict(estimate, result.parameter_estimate_mean)
 
 def test_estimate_type_default(result):
     result.configuration.estimate_type = 'MAP'

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -234,11 +234,11 @@ def test_get_parameter_estimate(result):
 
 
 def test_estimate_type_default(result):
-    result.estimate_type = 'MAP'
+    result.configuration.estimate_type = 'MAP'
     estimate = result.get_parameter_estimate()
     assert _close_numpy_dict(estimate, result.parameter_estimate_MAP)
 
-    result.estimate_type = 'mean'
+    result.configuration.estimate_type = 'mean'
     estimate = result.get_parameter_estimate()
     assert _close_numpy_dict(estimate, result.parameter_estimate_mean)
 

--- a/psignifit/tests/test_result.py
+++ b/psignifit/tests/test_result.py
@@ -36,8 +36,8 @@ def _build_result(parameter_estimate_MAP, parameter_estimate_mean, confidence_in
     # We don't care about most of the input parameters of the Result object, fill them with junk
     result = Result(
         configuration=Configuration(),
-        parameters_estimate_MAP=parameter_estimate_MAP,
-        parameters_estimate_mean=parameter_estimate_mean,
+        parameter_estimate_MAP=parameter_estimate_MAP,
+        parameter_estimate_mean=parameter_estimate_mean,
         confidence_intervals=confidence_intervals,
         data=np.random.rand(5, 3).tolist(),
         parameter_values={
@@ -80,11 +80,11 @@ def test_from_to_result_dict(result):
 
 def test_threshold_raises_error_when_outside_valid_range(result):
     # proportion correct lower than gamma
-    proportion_correct = np.array([result.parameters_estimate_MAP['gamma'] / 2.0])
+    proportion_correct = np.array([result.parameter_estimate_MAP['gamma'] / 2.0])
     with pytest.raises(ValueError):
         result.threshold(proportion_correct)
     # proportion correct higher than gamma
-    proportion_correct = np.array([result.parameters_estimate_MAP['lambda'] + 1e-4])
+    proportion_correct = np.array([result.parameter_estimate_MAP['lambda'] + 1e-4])
     with pytest.raises(ValueError):
         result.threshold(proportion_correct)
 
@@ -211,7 +211,7 @@ def test_save_load_result_json(result, tmp_path):
     assert result_file.exists()
     other = Result.load_json(result_file)
 
-    assert result.parameters_estimate_MAP == other.parameters_estimate_MAP
+    assert result.parameter_estimate_MAP == other.parameter_estimate_MAP
     assert result.configuration == other.configuration
     assert result.confidence_intervals == other.confidence_intervals
     assert np.all(np.isclose(result.data, other.data))
@@ -223,27 +223,27 @@ def test_save_load_result_json(result, tmp_path):
 
 
 def test_get_parameter_estimate(result):
-    estimate = result.get_parameters_estimate(estimate_type='MAP')
-    assert _close_numpy_dict(estimate, result.parameters_estimate_MAP)
+    estimate = result.get_parameter_estimate(estimate_type='MAP')
+    assert _close_numpy_dict(estimate, result.parameter_estimate_MAP)
 
-    estimate = result.get_parameters_estimate(estimate_type='mean')
-    assert _close_numpy_dict(estimate, result.parameters_estimate_mean)
+    estimate = result.get_parameter_estimate(estimate_type='mean')
+    assert _close_numpy_dict(estimate, result.parameter_estimate_mean)
 
     with pytest.raises(ValueError):
-        result.get_parameters_estimate(estimate_type='foo')
+        result.get_parameter_estimate(estimate_type='foo')
 
 
 def test_estimate_type_default(result):
     result.estimate_type = 'MAP'
-    estimate = result.get_parameters_estimate()
-    assert _close_numpy_dict(estimate, result.parameters_estimate_MAP)
+    estimate = result.get_parameter_estimate()
+    assert _close_numpy_dict(estimate, result.parameter_estimate_MAP)
 
     result.estimate_type = 'mean'
-    estimate = result.get_parameters_estimate()
-    assert _close_numpy_dict(estimate, result.parameters_estimate_mean)
+    estimate = result.get_parameter_estimate()
+    assert _close_numpy_dict(estimate, result.parameter_estimate_mean)
 
 
-def test_standard_parameters_estimate():
+def test_standard_parameter_estimate():
     width = 2.1
     threshold = 0.87
     parameter_estimate = {
@@ -261,7 +261,7 @@ def test_standard_parameters_estimate():
     # 1.644853626951472 is the normal PPF at alpha=0.95
     expected_scale = width / (2 * 1.644853626951472)
 
-    loc, scale = result.standard_parameters_estimate()
+    loc, scale = result.standard_parameter_estimate()
     np.testing.assert_allclose(loc, expected_loc)
     np.testing.assert_allclose(scale, expected_scale)
 


### PR DESCRIPTION
Following the discussion in #173 this PR reinstates the attribute `Result.parameter_estimate`, which becomes a property of the `Result` object. Internally we can still use `Result.get_parameter_estimate`, but for the naive user the interface is the same as it used to be in version `4.2`.

Note that for symmetry I have renamed the the attributes and the method to `Result.parameter_estimate_MAP`, `Result.parameter_estimate_mean` and `Result.get_parameter_estimate` without the `s` after `parameter`. The naming convention is now consistent for all related attributes/methods.

The documentation is updated too effectively reversing the work done in #174 .

Along the way I discovered that a couple of tests were not working and would pass unconditionally. An helper function was unconditionally returning `True`.

If this PR gets rejected we should at least cherry-pick the fix for the tests.

Fixes: #173 