### PR TITLE
Parametrize tests using the sigmoid classes, not the names

### DIFF
--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -325,6 +325,7 @@ _CLASS_BY_NAME = {
 
 ALL_SIGMOID_NAMES = set(_CLASS_BY_NAME.keys())
 ALL_SIGMOID_NAMES |= {'neg_' + name for name in ALL_SIGMOID_NAMES}
+ALL_SIGMOID_CLASSES = set(_CLASS_BY_NAME.values())
 
 
 def sigmoid_by_name(name, PC=None, alpha=None):

--- a/tests/test_param_recovery.py
+++ b/tests/test_param_recovery.py
@@ -1,17 +1,18 @@
+from itertools import product
 import warnings
 
 import numpy as np
 import pytest
 
 from psignifit import psignifit
-from psignifit.sigmoids import ALL_SIGMOID_NAMES, Gaussian, sigmoid_by_name
+from psignifit.sigmoids import ALL_SIGMOID_CLASSES, Gaussian
 from psignifit.tools import psychometric_with_eta
 from psignifit._utils import fp_error_handler
 
 
-@pytest.mark.parametrize("sigmoid_name", list(ALL_SIGMOID_NAMES))
+@pytest.mark.parametrize("sigmoid_class, negative", product(ALL_SIGMOID_CLASSES, [True, False]))
 @fp_error_handler(over='ignore', invalid='ignore')
-def test_parameter_recovery_2afc(sigmoid_name):
+def test_parameter_recovery_2afc(sigmoid_class, negative):
     width = 0.3
     stim_range = [0.01, 0.01 + width * 1.1]
     threshold = stim_range[1] / 2.5
@@ -21,7 +22,7 @@ def test_parameter_recovery_2afc(sigmoid_name):
     nsteps = 10
     stimulus_level = np.linspace(stim_range[0], stim_range[1], nsteps)
 
-    sigmoid = sigmoid_by_name(sigmoid_name)
+    sigmoid = sigmoid_class(negative=negative)
     perccorr = sigmoid(stimulus_level, threshold=threshold, width=width, gamma=gamma, lambd=lambda_)
 
     ntrials = np.ones(nsteps) * 9000000
@@ -123,9 +124,9 @@ def test_parameter_recovery_fixed_params(fixed_param):
         assert np.isclose(res.parameter_estimate_MAP[p], sim_params[p], rtol=1e-4, atol=1 / 40), f"failed for parameter {p} for estimation with fixed: {fixed_param}."
 
 
-@pytest.mark.parametrize("sigmoid_name", list(ALL_SIGMOID_NAMES))
+@pytest.mark.parametrize("sigmoid_class, negative", product(ALL_SIGMOID_CLASSES, [True, False]))
 @fp_error_handler(over='ignore', invalid='ignore')
-def test_parameter_recovery_YN(sigmoid_name):
+def test_parameter_recovery_YN(sigmoid_class, negative):
     width = 0.3
     stim_range = [0.001, 0.001 + width * 1.1]
     threshold = stim_range[1]/3
@@ -135,7 +136,7 @@ def test_parameter_recovery_YN(sigmoid_name):
     nsteps = 20
     stimulus_level = np.linspace(stim_range[0], stim_range[1], nsteps)
 
-    sigmoid = sigmoid_by_name(sigmoid_name)
+    sigmoid = sigmoid_class(negative=negative)
     perccorr = sigmoid(stimulus_level, threshold, width, gamma, lambda_)
     ntrials = np.ones(nsteps) * 900000000
     hits = (perccorr * ntrials).astype(int)
@@ -155,9 +156,9 @@ def test_parameter_recovery_YN(sigmoid_name):
     assert np.isclose(res.parameter_estimate_MAP['width'], width, atol=1e-4)
 
 
-@pytest.mark.parametrize("sigmoid_name", list(ALL_SIGMOID_NAMES))
+@pytest.mark.parametrize("sigmoid_class, negative", product(ALL_SIGMOID_CLASSES, [True, False]))
 @fp_error_handler(over='ignore', invalid='ignore')
-def test_parameter_recovery_eq_asymptote(sigmoid_name):
+def test_parameter_recovery_eq_asymptote(sigmoid_class, negative):
     width = 0.3
     stim_range = [0.001, 0.001 + width * 1.1]
     threshold = stim_range[1]/3
@@ -167,7 +168,7 @@ def test_parameter_recovery_eq_asymptote(sigmoid_name):
     nsteps = 20
     stimulus_level = np.linspace(stim_range[0], stim_range[1], nsteps)
 
-    sigmoid = sigmoid_by_name(sigmoid_name)
+    sigmoid = sigmoid_class(negative=negative)
     perccorr = sigmoid(stimulus_level, threshold, width, gamma, lambda_)
     ntrials = np.ones(nsteps) * 900000000
     hits = (perccorr * ntrials).astype(int)

--- a/tests/test_sigmoids.py
+++ b/tests/test_sigmoids.py
@@ -1,8 +1,11 @@
+from itertools import product
+
 import numpy as np
 from scipy import stats
 import pytest
 
 from psignifit import sigmoids
+from psignifit.sigmoids import ALL_SIGMOID_CLASSES, ALL_SIGMOID_NAMES
 
 
 def test_ALL_SIGMOID_NAMES():
@@ -12,10 +15,10 @@ def test_ALL_SIGMOID_NAMES():
         'weibull', 'neg_weibull',
         'tdist', 'student', 'heavytail', 'neg_tdist', 'neg_student', 'neg_heavytail')
     for name in TEST_SIGS:
-        assert name in sigmoids.ALL_SIGMOID_NAMES
+        assert name in ALL_SIGMOID_NAMES
 
 
-@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
+@pytest.mark.parametrize('sigmoid_name', ALL_SIGMOID_NAMES)
 def test_sigmoid_by_name(sigmoid_name):
     s = sigmoids.sigmoid_by_name(sigmoid_name)
     assert isinstance(s, sigmoids.Sigmoid)
@@ -51,28 +54,28 @@ def test_sigmoid_values(subclass, expected_y):
     np.testing.assert_allclose(y, expected_y, atol=1e-6)
 
 
-@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
-def test_sigmoid_inverse(sigmoid_name):
+@pytest.mark.parametrize('sigmoid_class, negative', product(ALL_SIGMOID_CLASSES, [True, False]))
+def test_sigmoid_inverse(sigmoid_class, negative):
     pc = 0.7
     alpha = 0.12
     threshold = 0.6
     width = 0.6
 
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=pc, alpha=alpha)
+    sigmoid = sigmoid_class(negative=negative, PC=pc, alpha=alpha)
     x = np.linspace(0.1, 0.9, 10)
     y = sigmoid(x, threshold, width)
     reverse_x = sigmoid.inverse(y, threshold, width)
     np.testing.assert_allclose(x, reverse_x, atol=1e-6)
 
 
-@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
-def test_sigmoid_slope(sigmoid_name):
+@pytest.mark.parametrize('sigmoid_class, negative', product(ALL_SIGMOID_CLASSES, [True, False]))
+def test_sigmoid_slope(sigmoid_class, negative):
     pc = 0.7
     alpha = 0.12
     threshold = 0.6
     width = 0.6
 
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=pc, alpha=alpha)
+    sigmoid = sigmoid_class(negative=negative, PC=pc, alpha=alpha)
     x = 0.4
     slope = sigmoid.slope(x, threshold, width)
 
@@ -85,8 +88,8 @@ def test_sigmoid_slope(sigmoid_name):
     np.testing.assert_allclose(slope, numerical_slope, atol=1e-6)
 
 
-@pytest.mark.parametrize('sigmoid_name', sigmoids.ALL_SIGMOID_NAMES)
-def test_sigmoid_sanity_check(sigmoid_name):
+@pytest.mark.parametrize('sigmoid_class, negative', product(ALL_SIGMOID_CLASSES, [True, False]))
+def test_sigmoid_sanity_check(sigmoid_class, negative):
     """ Basic sanity checks for sigmoids.
 
     These sanity checks test some basic relations between the parameters
@@ -100,7 +103,7 @@ def test_sigmoid_sanity_check(sigmoid_name):
     threshold = 0.54
     alpha = 0.083
 
-    sigmoid = sigmoids.sigmoid_by_name(sigmoid_name, PC=PC, alpha=alpha)
+    sigmoid = sigmoid_class(negative=negative, PC=PC, alpha=alpha)
     sigmoids.assert_sigmoid_sanity_checks(
         sigmoid, n_samples=10000, threshold=threshold, width=0.7,
     )


### PR DESCRIPTION
... because the names are sometimes aliases for the same class, as discussed in PR #190 