### PR TITLE
Add a docs page for the get_standard_parameters method.

### DIFF
--- a/docs/how_to/How-to-Get-Standard-Parameters.md
+++ b/docs/how_to/How-to-Get-Standard-Parameters.md
@@ -15,20 +15,20 @@ kernelspec:
 
 In psignifit 4 we chose to re-parametrized all sigmoids to the common parameter space spanned by threshold and width. To compare these parameters to values from the literature, older fits, etc. we provide a function transforming our parameters to the common standard parametrizations. It is implemented as a method on the results object, like this
 
-```{code-cell}
+```
 res.standard_parameter_estimate()
 ```
 
 For example, consider a Gaussian sigmoid with alpha=0.05, PC=0.5 fitted. The parameters we would get out, threshold and width, correspond to the standard parameters loc (mean) and scale (standard deviation) in the following way:
 
-```{code-cell}
+```
 expected_loc = threshold
 # 1.644853626951472 is the normal PPF at alpha=0.95
 expected_scale = width / (2 * 1.644853626951472)
 ```
 For different sigmoids these transforms will differ. The `standard_parameter_estimate` method computes the standard values for any of the different sigmoids.
 
-```{code-cell}
+```
 loc, scale = result.standard_parameters_estimate()
 ```
 

--- a/docs/how_to/How-to-Get-Standard-Parameters.md
+++ b/docs/how_to/How-to-Get-Standard-Parameters.md
@@ -1,8 +1,34 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
 # Get standard parameters
 
-The python version of psignifit does not yet contain the parameter
-conversion utility that the MATLAB version has,
-[as described here](https://github.com/wichmann-lab/psignifit/wiki/How-to-Get-Standard-Parameters).
+In psignifit 4 we chose to re-parametrized all sigmoids to the common parameter space spanned by threshold and width. To compare these parameters to values from the literature, older fits, etc. we provide a function transforming our parameters to the common standard parametrizations. It is implemented as a method on the results object, like this
 
-We are working in implenting this utility. Take a look at the [github issues](https://github.com/wichmann-lab/python-psignifit/issues) 
-to check out our progress.
+```{code-cell}
+res.standard_parameter_estimate()
+```
+
+For example, consider a Gaussian sigmoid with alpha=0.05, PC=0.5 fitted. The parameters we would get out, threshold and width, correspond to the standard parameters loc (mean) and scale (standard deviation) in the following way:
+
+```{code-cell}
+expected_loc = threshold
+# 1.644853626951472 is the normal PPF at alpha=0.95
+expected_scale = width / (2 * 1.644853626951472)
+```
+For different sigmoids these transforms will differ. The `standard_parameter_estimate` method computes the standard values for any of the different sigmoids.
+
+```{code-cell}
+loc, scale = result.standard_parameters_estimate()
+```
+

--- a/docs/how_to/How-to-Get-Standard-Parameters.md
+++ b/docs/how_to/How-to-Get-Standard-Parameters.md
@@ -16,7 +16,7 @@ kernelspec:
 In psignifit 4 we chose to re-parametrized all sigmoids to the common parameter space spanned by threshold and width. To compare these parameters to values from the literature, older fits, etc. we provide a function transforming our parameters to the common standard parametrizations. It is implemented as a method on the results object, like this
 
 ```
-res.standard_parameter_estimate()
+result.standard_parameter_estimate()
 ```
 
 For example, consider a Gaussian sigmoid with alpha=0.05, PC=0.5 fitted. The parameters we would get out, threshold and width, correspond to the standard parameters loc (mean) and scale (standard deviation) in the following way:


### PR DESCRIPTION
I tried to describe the function as best I knew how. Should we have a more in depth demonstration and tutorial, or do you think this is fine?