### PR TITLE
Fixes formatting of warning in documentation for advanced options

### DIFF
--- a/docs/examples/advanced-options.md
+++ b/docs/examples/advanced-options.md
@@ -100,8 +100,12 @@ options['CI_method'] = 'project'
 res = ps.psignifit(data, **options)
 ```
 
-## Threshold and width definitions```{warning}
-Options to change the 'thresh_PC' and 'width_alpha' (width parameter of the psychometric function) parameters are implemented in the matlab version of the code. In this python version they are still work in progress and can not be changed from their defaults.
+## Threshold and width definitions
+
+```{warning}
+Options to change the parameters 'thresh_PC' and 'width_alpha' (width parameter of the psychometric function) 
+are so far only implemented in the MATLAB version of psignifit.
+In this python version they are still work in progress and can not be changed from their defaults.
 ```
 
 This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).
@@ -111,6 +115,8 @@ To set it to a different value, for example to 90 %, you'll do
 ```{code-cell} ipython3
 options['thresh_PC'] = .9
 ```
+
+Note that this corresponds to a 95 \% in a 2AFC task.
 
 The definition of the `width` parameter of a psychometric function can be changed with the option `width_alpha`.
 

--- a/docs/examples/advanced-options.md
+++ b/docs/examples/advanced-options.md
@@ -102,10 +102,12 @@ res = ps.psignifit(data, **options)
 
 ## Threshold and width definitions
 
+### Threshold definition (`thresh_PC`)
+
 ```{warning}
-Options to change the parameters 'thresh_PC' and 'width_alpha' (width parameter of the psychometric function) 
-are so far only implemented in the MATLAB version of psignifit.
-In this python version they are still work in progress and can not be changed from their defaults.
+This option is only implemented in the MATLAB version of psignifit.
+For the python version the default value cannot be changed. 
+Adding this functionality is still work in progress.
 ```
 
 This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).
@@ -117,6 +119,9 @@ options['thresh_PC'] = .9
 ```
 
 Note that this corresponds to a 95 \% in a 2AFC task.
+
+
+### Width definition (`width_alpha`)
 
 The definition of the `width` parameter of a psychometric function can be changed with the option `width_alpha`.
 

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -14,7 +14,7 @@ kernelspec:
 # Change the threshold percentage correct 
 
 ```{warning}
-The option to change the parameter 'thresh_PC' is so far only implemented in the MATLAB version of psignifit.
+This option is so far only implemented in the MATLAB version of psignifit.
 In this python version they are still work in progress and can not be changed from the default.
 ```
 

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -14,9 +14,8 @@ kernelspec:
 # Change the threshold percentage correct 
 
 ```{warning}
-Options to change the parameters 'thresh_PC' and 'width_alpha' (width parameter of the psychometric function) 
-are so far only implemented in the MATLAB version of psignifit.
-In this python version they are still work in progress and can not be changed from their defaults.
+The option to change the parameter 'thresh_PC' is so far only implemented in the MATLAB version of psignifit.
+In this python version they are still work in progress and can not be changed from the default.
 ```
 
 This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -14,20 +14,17 @@ kernelspec:
 # Change the threshold percentage correct 
 
 ```{warning}
-This documentation page is still work in progress! Some information might be outdated.
+Options to change the parameters 'thresh_PC' and 'width_alpha' (width parameter of the psychometric function) 
+are so far only implemented in the MATLAB version of psignifit.
+In this python version they are still work in progress and can not be changed from their defaults.
 ```
 
-*Psignifit* defines the threshold as the point where the unscaled
-sigmoid is 0.5, i.e. half-way up its range. 
-Sometimes one wants to calculate thresholds for another percent correct level. 
+This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).
 
-You can change this default by setting the option `threshPC` with the value
-of the *proportion correct* you want. For example,
+To set it to a different value, for example to 90 %, you'll do
 
-```
-options['thresh_PC']   = 0.9
+```{code-cell} ipython3
+options = {'thresh_PC': .9}
 ```
 
-will set the threshold value at 0.9 on the unscaled sigmoid.
-
-
+Note that this corresponds to a 95 \% in a 2AFC task.

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -14,8 +14,9 @@ kernelspec:
 # Change the threshold percentage correct 
 
 ```{warning}
-This option is so far only implemented in the MATLAB version of psignifit.
-In this python version they are still work in progress and can not be changed from the default.
+This option is only implemented in the MATLAB version of psignifit.
+For the python version the default value cannot be changed. 
+Adding this functionality is still work in progress.
 ```
 
 This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).


### PR DESCRIPTION
It also copies the same text to the "How-To Change the threshold percentage correct", also including a warning that this is WIP