### PR TITLE
Allow setting `thresh_PC` to something other than 0.5

### DIFF
--- a/docs/examples/advanced-options.md
+++ b/docs/examples/advanced-options.md
@@ -104,13 +104,9 @@ res = ps.psignifit(data, **options)
 
 ### Threshold definition (`thresh_PC`)
 
-```{warning}
-This option is only implemented in the MATLAB version of psignifit.
-For the python version the default value cannot be changed. 
-Adding this functionality is still work in progress.
-```
-
-This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).
+This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values 
+are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the 
+guess rate of 50 % and ceiling performance 100%).
 
 To set it to a different value, for example to 90 %, you'll do
 

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -13,13 +13,9 @@ kernelspec:
 
 # Change the threshold percentage correct 
 
-```{warning}
-This option is only implemented in the MATLAB version of psignifit.
-For the python version the default value cannot be changed. 
-Adding this functionality is still work in progress.
-```
-
-This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess rate of 50 % and ceiling performance 100%).
+This option sets the proportion correct to correspond to the threshold on the *unscaled* sigmoid. Possible values are 
+in the range from 0 to 1, default is 0.5. The default corresponds to 75\% in a 2AFC task (midway between the guess 
+rate of 50 % and ceiling performance 100%).
 
 To set it to a different value, for example to 90 %, you'll do
 
@@ -28,3 +24,7 @@ options = {'thresh_PC': .9}
 ```
 
 Note that this corresponds to a 95 \% in a 2AFC task.
+
+Be aware that even though the interpretation of the threshold parameter changes with different values for `thresh_PC`,
+the prior over the threshold remains unchanged, which means that the prior over psychometric functions will be
+shifted. If this is not what you intended, please define a custom prior over the threshold.

--- a/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
+++ b/docs/how_to/How-to-Change-the-Threshold-Percent-Correct.md
@@ -25,6 +25,5 @@ options = {'thresh_PC': .9}
 
 Note that this corresponds to a 95 \% in a 2AFC task.
 
-Be aware that even though the interpretation of the threshold parameter changes with different values for `thresh_PC`,
-the prior over the threshold remains unchanged, which means that the prior over psychometric functions will be
-shifted. If this is not what you intended, please define a custom prior over the threshold.
+Be aware that the default prior over threshold assumes that the experimental stimulus range covers the range where 
+the threshold likely falls. If this doesn't match your setup, you'll need a custom prior.

--- a/psignifit/_priors.py
+++ b/psignifit/_priors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from typing import Tuple, Dict
 from functools import partial
+from typing import Tuple, Dict
+import warnings
 
 import numpy as np
 import scipy.stats
@@ -79,7 +80,10 @@ def eta_prior(x, k):
 def default_prior(parameter: str, stimulus_range: Tuple[float, float], width_min: float,
                    width_alpha: float, beta: float, threshold_percent_correct: float = 0.5) -> Dict[str, Prior]:
     if not np.isclose(threshold_percent_correct, 0.5):
-        raise ValueError("Default prior 'threshold' expects thresh_PC=0.5, got {thresh_PC = }")
+        warnings.warn("The `thresh_PC` parameters is set to a value different than 0.5. Be aware that the "
+                      "default prior over threshold remains unchanged, which means that the prior over psychometric "
+                      "functions will be shifted. If this is not what you intended, please define a custom prior "
+                      "over the threshold.")
 
     if parameter == 'threshold':
         prior = partial(threshold_prior, stimulus_range=stimulus_range)

--- a/psignifit/_priors.py
+++ b/psignifit/_priors.py
@@ -80,10 +80,10 @@ def eta_prior(x, k):
 def default_prior(parameter: str, stimulus_range: Tuple[float, float], width_min: float,
                    width_alpha: float, beta: float, threshold_percent_correct: float = 0.5) -> Dict[str, Prior]:
     if not np.isclose(threshold_percent_correct, 0.5):
-        warnings.warn("The `thresh_PC` parameters is set to a value different than 0.5. Be aware that the "
-                      "default prior over threshold remains unchanged, which means that the prior over psychometric "
-                      "functions will be shifted. If this is not what you intended, please define a custom prior "
-                      "over the threshold.")
+        warnings.warn(f"The `thresh_PC` parameter is set to {threshold_percent_correct}, not the default 0.5. "
+                      f"Be aware that the default prior over threshold assumes that the experimental stimulus range "
+                      f"covers the range where the threshold likely falls. If this doesn't match your setup, you'll "
+                      f"need a custom prior. See the documentation for guidance.")
 
     if parameter == 'threshold':
         prior = partial(threshold_prior, stimulus_range=stimulus_range)


### PR DESCRIPTION
Fix #204 

- turned the Exception raised when `thresh_PC != 0.5` into a meaningful warning
- fixed the position of the CI over threshold in `plot_psychometric_function` then `thresh_PC != 0.5`