### PR TITLE
cast estimated parameters from Numpy scalars  to Python floats

### DIFF
--- a/psignifit/_posterior.py
+++ b/psignifit/_posterior.py
@@ -250,7 +250,10 @@ def maximize_posterior(data, param_init: Dict[str, float], param_fixed: Dict[str
     init_values = [value for name, value in sorted(param_init.items())]
     optimized_values = optimize.fmin(objective, init_values, disp=False)
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
-    optimized_param = dict(zip(sorted(param_init.keys()), optimized_values))
+    optimized_param = dict(zip(sorted(param_init.keys()), optimized_values.tolist()))
+    # convert fixed parameters to Python floats (they are numpy scalars)
+    for key, value in param_fixed.items():
+        param_fixed[key] = float(value)
     return {**param_fixed, **optimized_param}
 
 

--- a/psignifit/_posterior.py
+++ b/psignifit/_posterior.py
@@ -5,8 +5,8 @@ import numpy as np
 import scipy.special as sp
 from scipy import optimize
 
-from ._utils import fp_error_handler, PsignifitException, cast_np_scalar
-from ._typing import Prior, ParameterGrid
+from ._utils import PsignifitException, cast_np_scalar, fp_error_handler
+from ._typing import ParameterGrid, Prior
 from .sigmoids import Sigmoid
 
 # accomodate numpy versions < 2

--- a/psignifit/_posterior.py
+++ b/psignifit/_posterior.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.special as sp
 from scipy import optimize
 
-from ._utils import fp_error_handler, PsignifitException
+from ._utils import fp_error_handler, PsignifitException, cast_np_scalar
 from ._typing import Prior, ParameterGrid
 from .sigmoids import Sigmoid
 
@@ -248,10 +248,11 @@ def maximize_posterior(data, param_init: Dict[str, float], param_fixed: Dict[str
 
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
     init_values = [value for name, value in sorted(param_init.items())]
-    optimized_values = optimize.fmin(objective, init_values, disp=False)
+    optimized_values = [cast_np_scalar(value) for value in optimize.fmin(objective, init_values, disp=False)]
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
     optimized_param = dict(zip(sorted(param_init.keys()), optimized_values))
-    return {**param_fixed, **optimized_param}
+    out_param_fixed = { key: cast_np_scalar(value) for key, value in param_fixed.items()}
+    return {**out_param_fixed, **optimized_param}
 
 
 def marginalize_posterior(parameter_grid: ParameterGrid, posterior_mass: np.ndarray) -> Dict[str, np.ndarray]:

--- a/psignifit/_posterior.py
+++ b/psignifit/_posterior.py
@@ -248,11 +248,12 @@ def maximize_posterior(data, param_init: Dict[str, float], param_fixed: Dict[str
 
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
     init_values = [value for name, value in sorted(param_init.items())]
-    optimized_values = [cast_np_scalar(value) for value in optimize.fmin(objective, init_values, disp=False)]
+    optimized_values = optimize.fmin(objective, init_values, disp=False)
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
     optimized_param = dict(zip(sorted(param_init.keys()), optimized_values))
-    out_param_fixed = { key: cast_np_scalar(value) for key, value in param_fixed.items()}
-    return {**out_param_fixed, **optimized_param}
+    cast_optimized_param = { key: cast_np_scalar(value) for key, value in optimized_param.items() }
+    cast_param_fixed = { key: cast_np_scalar(value) for key, value in param_fixed.items() }
+    return {**cast_param_fixed, **cast_optimized_param}
 
 
 def marginalize_posterior(parameter_grid: ParameterGrid, posterior_mass: np.ndarray) -> Dict[str, np.ndarray]:

--- a/psignifit/_posterior.py
+++ b/psignifit/_posterior.py
@@ -250,10 +250,7 @@ def maximize_posterior(data, param_init: Dict[str, float], param_fixed: Dict[str
     init_values = [value for name, value in sorted(param_init.items())]
     optimized_values = optimize.fmin(objective, init_values, disp=False)
     # "sorted" is required so that the parameters are matched to the axes in  alphabetical order
-    optimized_param = dict(zip(sorted(param_init.keys()), optimized_values.tolist()))
-    # convert fixed parameters to Python floats (they are numpy scalars)
-    for key, value in param_fixed.items():
-        param_fixed[key] = float(value)
+    optimized_param = dict(zip(sorted(param_init.keys()), optimized_values))
     return {**param_fixed, **optimized_param}
 
 

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -140,9 +140,9 @@ class Result:
                 lambd_ci = self.confidence_intervals['lambda'][coverage_key]
             ci_min = sigmoid.inverse(proportion_correct, thres_ci[0], width_ci[0], gamma_ci[0], lambd_ci[0])
             ci_max = sigmoid.inverse(proportion_correct, thres_ci[1], width_ci[1], gamma_ci[1], lambd_ci[1])
-            new_threshold_ci[coverage_key] = [float(ci_min), float(ci_max)]
+            new_threshold_ci[coverage_key] = [ci_min, ci_max]
 
-        return float(new_threshold), new_threshold_ci
+        return new_threshold, new_threshold_ci
 
     def slope(self, stimulus_level: np.ndarray, estimate_type: Optional[EstimateType]=None) -> np.ndarray:
         """ Slope of the psychometric function at a given stimulus levels.

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -140,9 +140,9 @@ class Result:
                 lambd_ci = self.confidence_intervals['lambda'][coverage_key]
             ci_min = sigmoid.inverse(proportion_correct, thres_ci[0], width_ci[0], gamma_ci[0], lambd_ci[0])
             ci_max = sigmoid.inverse(proportion_correct, thres_ci[1], width_ci[1], gamma_ci[1], lambd_ci[1])
-            new_threshold_ci[coverage_key] = [ci_min, ci_max]
+            new_threshold_ci[coverage_key] = [float(ci_min), float(ci_max)]
 
-        return new_threshold, new_threshold_ci
+        return float(new_threshold), new_threshold_ci
 
     def slope(self, stimulus_level: np.ndarray, estimate_type: Optional[EstimateType]=None) -> np.ndarray:
         """ Slope of the psychometric function at a given stimulus levels.

--- a/psignifit/_utils.py
+++ b/psignifit/_utils.py
@@ -48,3 +48,10 @@ def check_data(data: np.ndarray) -> np.ndarray:
                                  ' integer numbers!')
 
     return data
+
+def cast_np_scalar(x):
+    """Cast an object to a Python scalar if it is a numpy scalar"""
+    if isinstance(x, np.number):
+        return x.item()
+    else:
+        return x

--- a/psignifit/_utils.py
+++ b/psignifit/_utils.py
@@ -50,7 +50,9 @@ def check_data(data: np.ndarray) -> np.ndarray:
     return data
 
 def cast_np_scalar(x):
-    """Cast an object to a Python scalar if it is a numpy scalar"""
+    """Cast an object to a Python scalar if it is a numpy scalar.
+
+    The function is a no-op if x is not a numpy scalar."""
     if isinstance(x, np.number):
         return x.item()
     else:

--- a/psignifit/_utils.py
+++ b/psignifit/_utils.py
@@ -49,6 +49,7 @@ def check_data(data: np.ndarray) -> np.ndarray:
 
     return data
 
+
 def cast_np_scalar(x):
     """Cast an object to a Python scalar if it is a numpy scalar.
 

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -102,8 +102,8 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         _warn_marginal_sanity_checks(marginals)
 
     if conf.experiment_type == 'equal asymptote':
-        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda']
-        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda']
+        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda'].copy()
+        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda'].copy()
         grid['gamma'] = grid['lambda'].copy()
         priors['gamma'] = priors['lambda']
         marginals['gamma'] = marginals['lambda'].copy()
@@ -249,7 +249,7 @@ def _fit_parameters(data: np.ndarray, bounds: ParameterBounds,
     params_values = [grid[p] for p in sorted(grid.keys())]
     params_grid = np.meshgrid(*params_values, indexing='ij')
     for idx, p in enumerate(sorted(grid.keys())):
-        estimate_mean_dict[p] = float((params_grid[idx] * posteriors).sum())
+        estimate_mean_dict[p] = (params_grid[idx] * posteriors).sum()
 
     # Estimate parameters as the mode of the posterior (MAP)
     fixed_param = {}

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -102,8 +102,8 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         _warn_marginal_sanity_checks(marginals)
 
     if conf.experiment_type == 'equal asymptote':
-        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda'].copy()
-        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda'].copy()
+        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda']
+        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda']
         grid['gamma'] = grid['lambda'].copy()
         priors['gamma'] = priors['lambda']
         marginals['gamma'] = marginals['lambda'].copy()

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -102,8 +102,8 @@ def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
         _warn_marginal_sanity_checks(marginals)
 
     if conf.experiment_type == 'equal asymptote':
-        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda'].copy()
-        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda'].copy()
+        estimate_MAP_dict['gamma'] = estimate_MAP_dict['lambda']
+        estimate_mean_dict['gamma'] = estimate_mean_dict['lambda']
         grid['gamma'] = grid['lambda'].copy()
         priors['gamma'] = priors['lambda']
         marginals['gamma'] = marginals['lambda'].copy()
@@ -249,7 +249,7 @@ def _fit_parameters(data: np.ndarray, bounds: ParameterBounds,
     params_values = [grid[p] for p in sorted(grid.keys())]
     params_grid = np.meshgrid(*params_values, indexing='ij')
     for idx, p in enumerate(sorted(grid.keys())):
-        estimate_mean_dict[p] = (params_grid[idx] * posteriors).sum()
+        estimate_mean_dict[p] = float((params_grid[idx] * posteriors).sum())
 
     # Estimate parameters as the mode of the posterior (MAP)
     fixed_param = {}

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -13,7 +13,7 @@ from ._posterior import posterior_grid, maximize_posterior, marginalize_posterio
 from ._priors import setup_priors
 from ._result import Result
 from ._typing import ParameterBounds, Prior
-from ._utils import (PsignifitException, check_data)
+from ._utils import PsignifitException, check_data, cast_np_scalar
 
 
 def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,
@@ -249,7 +249,7 @@ def _fit_parameters(data: np.ndarray, bounds: ParameterBounds,
     params_values = [grid[p] for p in sorted(grid.keys())]
     params_grid = np.meshgrid(*params_values, indexing='ij')
     for idx, p in enumerate(sorted(grid.keys())):
-        estimate_mean_dict[p] = (params_grid[idx] * posteriors).sum()
+        estimate_mean_dict[p] = cast_np_scalar((params_grid[idx] * posteriors).sum())
 
     # Estimate parameters as the mode of the posterior (MAP)
     fixed_param = {}

--- a/psignifit/psignifit.py
+++ b/psignifit/psignifit.py
@@ -6,14 +6,14 @@ from typing import Dict, Optional
 import numpy as np
 
 from . import sigmoids
-from ._parameter import parameter_bounds, masked_parameter_bounds, parameter_grid
-from ._configuration import Configuration
 from ._confidence import confidence_intervals
-from ._posterior import posterior_grid, maximize_posterior, marginalize_posterior
+from ._configuration import Configuration
+from ._parameter import masked_parameter_bounds, parameter_bounds, parameter_grid
+from ._posterior import marginalize_posterior, maximize_posterior, posterior_grid
 from ._priors import setup_priors
 from ._result import Result
 from ._typing import ParameterBounds, Prior
-from ._utils import PsignifitException, check_data, cast_np_scalar
+from ._utils import PsignifitException, cast_np_scalar, check_data
 
 
 def psignifit(data: np.ndarray, conf: Optional[Configuration] = None,

--- a/psignifit/sigmoids.py
+++ b/psignifit/sigmoids.py
@@ -7,6 +7,7 @@ from typing import Optional, TypeVar
 import numpy as np
 import scipy.stats
 
+from ._utils import cast_np_scalar
 
 # sigmoid can be calculated on single floats, or on numpy arrays of floats
 N = TypeVar('N', float, np.ndarray)
@@ -80,7 +81,7 @@ class Sigmoid:
         if self.negative:
             value = 1 - value
 
-        return value
+        return cast_np_scalar(value)
 
     def slope(self, stimulus_level: N, threshold: N, width: N, gamma: N = 0, lambd: N = 0) -> N:
         """ Calculate the slope at specified stimulus levels.
@@ -99,9 +100,10 @@ class Sigmoid:
         slope = (1 - gamma - lambd) * raw_slope
 
         if self.negative:
-            return -slope
+            out = -slope
         else:
-            return slope
+            out = slope
+        return cast_np_scalar(out)
 
     def inverse(self, prop_correct: N, threshold: N, width: N,
                 gamma: Optional[N] = None, lambd: Optional[N] = None) -> np.ndarray:
@@ -124,9 +126,7 @@ class Sigmoid:
         if self.negative:
             prop_correct = 1 - prop_correct
 
-        result = self._inverse(prop_correct, threshold, width)
-
-        return result
+        return cast_np_scalar(self._inverse(prop_correct, threshold, width))
 
     def standard_parameters(self, threshold: N, width: N) -> tuple:
         """ Transforms the parameters threshold and width to a standard parametrization.
@@ -143,7 +143,7 @@ class Sigmoid:
         Returns:
             Standard parameters (loc, scale) for the sigmoid subclass.
         """
-        return self._standard_parameters(threshold, width)
+        return [cast_np_scalar(value) for value in self._standard_parameters(threshold, width)]
 
     # --- Private interface
 
@@ -161,8 +161,7 @@ class Sigmoid:
             Proportion correct at the stimulus level values
         """
         loc, scale = self._standard_parameters(threshold=threshold, width=width)
-        value = self._cdf(stimulus_level, loc=loc, scale=scale)
-        return value
+        return cast_np_scalar(self._cdf(stimulus_level, loc=loc, scale=scale))
 
     def _slope(self, stimulus_level: N, threshold: N, width: N) -> N:
         """ Compute the slope of the sigmoid at a given stimulus level.
@@ -178,8 +177,7 @@ class Sigmoid:
             Slope at the stimulus level values
         """
         loc, scale = self._standard_parameters(threshold=threshold, width=width)
-        raw_slope = self._pdf(stimulus_level, loc=loc, scale=scale)
-        return raw_slope
+        return cast_np_scalar(self._pdf(stimulus_level, loc=loc, scale=scale))
 
     def _inverse(self, prop_correct: N, threshold: N, width: N) -> N:
         """ Compute the stimulus value at different proportion correct values.
@@ -195,8 +193,7 @@ class Sigmoid:
             Stimulus values corresponding to the proportion correct values.
         """
         loc, scale = self._standard_parameters(threshold=threshold, width=width)
-        result = self._ppf(prop_correct, loc=loc, scale=scale)
-        return result
+        return cast_np_scalar(self._ppf(prop_correct, loc=loc, scale=scale))
 
     def _standard_parameters(self, threshold: N, width: N) -> list:
         """ Transforms parameters threshold and width to a standard parametrization.

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -44,13 +44,20 @@ def test_py_not_np_scalar_param_estimate(input_data, fixed_parm):
     for parm, value in result.parameter_estimate_MAP.items():
         assert type(value) in (int, float), f'MAP parameter estimate {parm} is not a Python int/float'
 
-def test_py_not_np_scalar_get_threshold(input_data):
+def test_py_not_np_scalar_threshold(input_data):
     result = psignifit(input_data[:3,:], experiment_type='yes/no')
     value, ci = result.threshold(0.5)
     assert type(value) in (int, float)
     for pc, (low, high) in ci.items():
         assert type(low) in (int, float), f'Confidence interval {pc} lower bound is not a Python int/float'
         assert type(high) in (int, float), f'Confidence interval {pc} upper bound is not a Python int/float'
+
+def test_py_not_np_scalar_slope(input_data):
+    result = psignifit(input_data[:3,:], experiment_type='yes/no')
+    value = result.slope(0.5)
+    assert type(value) in (int, float)
+    value = result.slope_at_proportion_correct(0.5, 0.3)
+    assert type(value) in (int, float)
 
 @pytest.mark.parametrize('negative', (True, False))
 @pytest.mark.parametrize('sigmoid_class', ALL_SIGMOID_CLASSES)

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -68,3 +68,11 @@ def test_py_not_np_scalar_sigmoid_methods(negative, sigmoid_class, method):
     y = getattr(sigmoid, method)(x, thr, wd)
     assert type(y) in (int, float), f'method of Sigmoid does not return Python int/float'
 
+@pytest.mark.parametrize('negative', (True, False))
+@pytest.mark.parametrize('sigmoid_class', ALL_SIGMOID_CLASSES)
+def test_py_not_np_scalar_sigmoid_standard_parameters(negative, sigmoid_class):
+    x, thr, wd = 0.3, 0.2, 0.1
+    sigmoid = sigmoid_class()
+    st_params = sigmoid.standard_parameters(thr, wd)
+    for parm in st_params:
+        assert type(parm) in (int, float), f'Sigmoid.standard_parameters does not return Python int/float'

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -1,8 +1,21 @@
+import numbers
+
 import numpy as np
 import pytest
 
 from psignifit import psignifit
+from psignifit._utils import cast_np_scalar
 from .fixtures import input_data
+
+@pytest.mark.parametrize('num', (1, 1., np.int64(1), np.float64(1.)))
+def test_cast_np_scalar_numbers(num):
+    cast = cast_np_scalar(num)
+    assert not isinstance(cast, np.number)
+    assert isinstance(cast, numbers.Number)
+
+def test_cast_np_scalar_ndarray_noop():
+    cast = cast_np_scalar(np.ones(1))
+    assert isinstance(cast, np.ndarray)
 
 @pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
 def test_floats_not_0D_ndarray_ci(input_data, ci_method):

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from psignifit import psignifit
+from .fixtures import input_data
+
+@pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
+def test_floats_not_0D_ndarray_ci(input_data, ci_method):
+    result = psignifit(input_data[:3,:], experiment_type='yes/no', CI_method=ci_method)
+    for parm, CI in result.confidence_intervals.items():
+        for pc, (low, high) in CI.items():
+            assert type(low) in (int, float), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
+            assert type(high) in (int, float), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'
+
+@pytest.mark.parametrize('fixed_parm', [(None, None),
+                                        ('lambda', 3e-7),
+                                        ('gamma', 0.5),
+                                        ('eta', 1e-4),
+                                        ('threshold', 0.0046),
+                                        ('width', 0.0046)])
+def test_floats_not_0D_ndarray_param_estimate(input_data, fixed_parm):
+    parm, value = fixed_parm
+    if parm:
+        fixed_parm = {parm: value}
+    else:
+        fixed_parm = {}
+    result = psignifit(input_data[:3,:], experiment_type='yes/no', fixed_parameters=fixed_parm)
+    for parm, value in result.parameter_estimate_mean.items():
+        assert type(value) in (int, float), f'Mean parameter estimate {parm} is not a Python int/float'
+    for parm, value in result.parameter_estimate_MAP.items():
+        assert type(value) in (int, float), f'MAP parameter estimate {parm} is not a Python int/float'
+
+
+def test_floats_not_0D_ndarray_get_threshold(input_data):
+    result = psignifit(input_data[:3,:], experiment_type='yes/no')
+    value, ci = result.threshold(0.5)
+    assert type(value) in (int, float)
+    for pc, (low, high) in ci.items():
+        assert type(low) in (int, float), f'Confidence interval {pc} lower bound is not a Python int/float'
+        assert type(high) in (int, float), f'Confidence interval {pc} upper bound is not a Python int/float'
+

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -14,9 +14,11 @@ def test_cast_np_scalar_numbers(num):
     assert not isinstance(cast, np.number)
     assert isinstance(cast, numbers.Number)
 
+
 def test_cast_np_scalar_ndarray_noop():
     cast = cast_np_scalar(np.ones(1))
     assert isinstance(cast, np.ndarray)
+
 
 @pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
 def test_py_not_np_scalar_ci(input_data, ci_method):
@@ -25,6 +27,7 @@ def test_py_not_np_scalar_ci(input_data, ci_method):
         for pc, (low, high) in CI.items():
             assert type(low) in (int, float), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
             assert type(high) in (int, float), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'
+
 
 @pytest.mark.parametrize('fixed_parm', [(None, None),
                                         ('lambda', 3e-7),
@@ -44,6 +47,7 @@ def test_py_not_np_scalar_param_estimate(input_data, fixed_parm):
     for parm, value in result.parameter_estimate_MAP.items():
         assert type(value) in (int, float), f'MAP parameter estimate {parm} is not a Python int/float'
 
+
 def test_py_not_np_scalar_threshold(input_data):
     result = psignifit(input_data[:3,:], experiment_type='yes/no')
     value, ci = result.threshold(0.5)
@@ -52,12 +56,14 @@ def test_py_not_np_scalar_threshold(input_data):
         assert type(low) in (int, float), f'Confidence interval {pc} lower bound is not a Python int/float'
         assert type(high) in (int, float), f'Confidence interval {pc} upper bound is not a Python int/float'
 
+
 def test_py_not_np_scalar_slope(input_data):
     result = psignifit(input_data[:3,:], experiment_type='yes/no')
     value = result.slope(0.5)
     assert type(value) in (int, float)
     value = result.slope_at_proportion_correct(0.5, 0.3)
     assert type(value) in (int, float)
+
 
 @pytest.mark.parametrize('negative', (True, False))
 @pytest.mark.parametrize('sigmoid_class', ALL_SIGMOID_CLASSES)
@@ -67,6 +73,7 @@ def test_py_not_np_scalar_sigmoid_methods(negative, sigmoid_class, method):
     sigmoid = sigmoid_class()
     y = getattr(sigmoid, method)(x, thr, wd)
     assert type(y) in (int, float), f'method of Sigmoid does not return Python int/float'
+
 
 @pytest.mark.parametrize('negative', (True, False))
 @pytest.mark.parametrize('sigmoid_class', ALL_SIGMOID_CLASSES)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -344,25 +344,3 @@ def test_posterior_samples(result, random_state):
     empirical_posterior = counts / n_samples
     np.testing.assert_allclose(empirical_posterior, posterior, atol=1e-2)
 
-@pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
-@pytest.mark.parametrize('fixed_parm', [(None, None),
-                                        ('lambda', 3e-7),
-                                        ('gamma', 0.5),
-                                        ('eta', 1e-4),
-                                        ('threshold', 0.0046),
-                                        ('width', 0.0046)])
-def test_floats_not_0D_ndarray(input_data, ci_method, fixed_parm):
-    parm, value = fixed_parm
-    if parm:
-        fixed_parm = {parm: value}
-    else:
-        fixed_parm = {}
-    result = psignifit(input_data[:3,:], experiment_type='yes/no', fixed_parameters=fixed_parm, CI_method=ci_method)
-    for parm, value in result.parameter_estimate_mean.items():
-        assert type(value) in (int, float), f'Mean parameter estimate {parm} is not a Python int/float'
-    for parm, value in result.parameter_estimate_MAP.items():
-        assert type(value) in (int, float), f'MAP parameter estimate {parm} is not a Python int/float'
-    for parm, CI in result.confidence_intervals.items():
-        for pc, (low, high) in CI.items():
-            assert type(low) in (int, float), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
-            assert type(high) in (int, float), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -298,7 +298,7 @@ def test_threshold_bug_172(input_data):
 
 
 def test_posterior_samples_raises_if_not_debug(input_data):
-    result = psignifit(input_data)
+    result = psignifit(input_data[:3,:])
     with pytest.raises(ValueError):
         result.posterior_samples(n_samples=10)
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -359,10 +359,10 @@ def test_floats_not_0D_ndarray(input_data, ci_method, fixed_parm):
         fixed_parm = {}
     result = psignifit(input_data[:3,:], experiment_type='yes/no', fixed_parameters=fixed_parm, CI_method=ci_method)
     for parm, value in result.parameter_estimate_mean.items():
-        assert isinstance(value, (int, float)), f'Mean parameter estimate {parm} is not a Python int/float'
+        assert type(value) in (int, float), f'Mean parameter estimate {parm} is not a Python int/float'
     for parm, value in result.parameter_estimate_MAP.items():
-        assert isinstance(value, (int, float)), f'MAP parameter estimate {parm} is not a Python int/float'
+        assert type(value) in (int, float), f'MAP parameter estimate {parm} is not a Python int/float'
     for parm, CI in result.confidence_intervals.items():
         for pc, (low, high) in CI.items():
-            assert isinstance(low, (int, float)), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
-            assert isinstance(high, (int, float)), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'
+            assert type(low) in (int, float), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
+            assert type(high) in (int, float), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -343,3 +343,26 @@ def test_posterior_samples(result, random_state):
 
     empirical_posterior = counts / n_samples
     np.testing.assert_allclose(empirical_posterior, posterior, atol=1e-2)
+
+@pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
+@pytest.mark.parametrize('fixed_parm', [(None, None),
+                                        ('lambda', 3e-7),
+                                        ('gamma', 0.5),
+                                        ('eta', 1e-4),
+                                        ('threshold', 0.0046),
+                                        ('width', 0.0046)])
+def test_floats_not_0D_ndarray(input_data, ci_method, fixed_parm):
+    parm, value = fixed_parm
+    if parm:
+        fixed_parm = {parm: value}
+    else:
+        fixed_parm = {}
+    result = psignifit(input_data[:3,:], experiment_type='yes/no', fixed_parameters=fixed_parm, CI_method=ci_method)
+    for parm, value in result.parameter_estimate_mean.items():
+        assert isinstance(value, (int, float)), f'Mean parameter estimate {parm} is not a Python int/float'
+    for parm, value in result.parameter_estimate_MAP.items():
+        assert isinstance(value, (int, float)), f'MAP parameter estimate {parm} is not a Python int/float'
+    for parm, CI in result.confidence_intervals.items():
+        for pc, (low, high) in CI.items():
+            assert isinstance(low, (int, float)), f'Confidence interval {pc} lower bound for {parm} is not a Python int/float'
+            assert isinstance(high, (int, float)), f'Confidence interval {pc} upper bound for  {parm} is not a Python int/float'


### PR DESCRIPTION
Do not return Numpy scalars, i.e. 0-D Numpy arrays. Use Python floats instead.
This does not have any numerical relevance, but makes the returned values easier to read, especially during interactive work and in the documentation. I am using this PR already in #211 .

I have solved this by introducing a new utility `cast_np_scalar`, which can be called unconditionally on anything. If the input is a numpy scalar it will be converted to a Python scalar (typically, float or int), otherwise it is a no-op. This is necessary because we have functions and methods both in `Result` and `Sigmoid` which work both with Numpy arrays and scalars. We don't want to touch the arrays.

All this is needed because Numpy 2 implemented [NEP 51](https://numpy.org/neps/nep-0051-scalar-representation.html) and numpy scalars have a repr of the form `np.float64(1.2)`, i.e. they do not look like Python scalars anymore. Numpy returns a scalar as a result of operations on arrays where the dimensionality reduction due to the operation would lead to a 0-D array, for example `array.sum()`.