### PR TITLE
Add a `proportion_correct` method to the `Result` object to get proportion correct values from the fitted psychometric function

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,6 +43,7 @@ sphinx:
     - sphinx.ext.napoleon
     
   config:
+    myst_heading_anchors : 4
     suppress_warnings : ["etoc.toctree"] # Workaround for: https://github.com/executablebooks/sphinx-external-toc/issues/36
                                          # and: https://github.com/executablebooks/sphinx-external-toc/issues/79
     autodoc_default_options: {

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,6 +23,7 @@ parts:
     - file: how_to/How-to-Fix-Parameters
     - file: how_to/How-to-Change-the-Threshold-Percent-Correct
     - file: how_to/How-to-Get-Standard-Parameters
+    - file: how_to/How-to-Get-Proportion-Correct.md
     
   - caption: Extras
     chapters:

--- a/docs/how_to/How-to-Get-Proportion-Correct.md
+++ b/docs/how_to/How-to-Get-Proportion-Correct.md
@@ -49,8 +49,8 @@ Note that `stimulus_levels` can be a NumPy array, for example `stimulus_levels =
 We can also get the proportion correct values with added noise derived from the estimated overdispersion
 parameter `eta` (see the [Parameter recovery demo](../examples/parameter_recovery_demo.md#and-now-with-some-more-realistic-data)
 and the [*Vision Research* paper](http://www.sciencedirect.com/science/article/pii/S0042698916000390)
-for more info about the `eta` parameter). In essence, were you to draw a lot of these proportion correct values, their
-variance would be compatible with that of samples from a beta binomial distribution with scale paramter equal to `eta`.
+for more info about the `eta` parameter). In essence, were you to draw several proportion correct values, their
+variance would be compatible with that of samples from a beta binomial distribution with scale parameter equal to `eta`.
 
 ```{code-cell} ipython3
 stimulus_levels = [0.0012, 0.0013]
@@ -58,7 +58,7 @@ prop_correct = res.proportion_correct(stimulus_levels, with_eta=True)
 print(prop_correct)
 ```
 
-If you are intersted in the proportion correct values based on the `mean` estimate instead of the default
+If you are interested in the proportion correct values based on the `mean` estimate instead of the default
 `MAP` estimate, you can get them with:
 
 ```{code-cell} ipython3

--- a/docs/how_to/How-to-Get-Proportion-Correct.md
+++ b/docs/how_to/How-to-Get-Proportion-Correct.md
@@ -1,0 +1,66 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Get proportion correct values
+
+This demo shows how to get proportion correct values given from the fitted psychometric function,
+
+We will need some fitted function for illustration. Thus we first fit our
+standard data from [basic usage example](../basic-usage):
+
+
+```{code-cell} ipython3
+import numpy as np
+
+import psignifit as ps
+
+data = np.array([[0.0010, 45.0000, 90.0000], [0.0015, 50.0000, 90.0000],
+                 [0.0020, 44.0000, 90.0000], [0.0025, 44.0000, 90.0000],
+                 [0.0030, 52.0000, 90.0000], [0.0035, 53.0000, 90.0000],
+                 [0.0040, 62.0000, 90.0000], [0.0045, 64.0000, 90.0000],
+                 [0.0050, 76.0000, 90.0000], [0.0060, 79.0000, 90.0000],
+                 [0.0070, 88.0000, 90.0000], [0.0080, 90.0000, 90.0000],
+                 [0.0100, 90.0000, 90.0000]])
+
+res = ps.psignifit(data, sigmoid='norm', experiment_type='2AFC')
+```
+
+Now, let's say we want to get the proportion correct values for stimulus levels `0.0012` and `0.0013`, which
+were not measured during the experiment:
+
+```{code-cell} ipython3
+stimulus_levels = [0.0012, 0.0013]
+prop_correct = res.proportion_correct(stimulus_levels)
+print(prop_correct)
+```
+
+We can also get the proportion correct values with added noise derived from the estimated overdispersion
+parameter `eta` (see the [Parameter recovery demo](../examples/parameter_recovery_demo.md#and-now-with-some-more-realistic-data)
+and the [*Vision Research* paper](http://www.sciencedirect.com/science/article/pii/S0042698916000390)
+for more info about the `eta` parameter). In essence, were you to draw a lot of these proportion correct values, their
+variance would be compatible with that of samples from a beta binomial distribution with scale paramter equal to `eta`.
+
+```{code-cell} ipython3
+stimulus_levels = [0.0012, 0.0013]
+prop_correct = res.proportion_correct(stimulus_levels, with_eta=True)
+print(prop_correct)
+```
+
+If you are intersted in the proportion correct values based on the `mean` estimate instead of the default
+`MAP` estimate, you can get them with:
+
+```{code-cell} ipython3
+stimulus_levels = [0.0012, 0.0013]
+prop_correct = res.proportion_correct(stimulus_levels, estimate_type='mean')
+print(prop_correct)
+```

--- a/docs/how_to/How-to-Get-Proportion-Correct.md
+++ b/docs/how_to/How-to-Get-Proportion-Correct.md
@@ -44,6 +44,8 @@ prop_correct = res.proportion_correct(stimulus_levels)
 print(prop_correct)
 ```
 
+Note that `stimulus_levels` can be a NumPy array, for example `stimulus_levels = np.linspace(0.012, 0.015, n=10)`.
+
 We can also get the proportion correct values with added noise derived from the estimated overdispersion
 parameter `eta` (see the [Parameter recovery demo](../examples/parameter_recovery_demo.md#and-now-with-some-more-realistic-data)
 and the [*Vision Research* paper](http://www.sciencedirect.com/science/article/pii/S0042698916000390)

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -179,7 +179,7 @@ class Result:
             out = psychometric_with_eta(stimulus_level, param['threshold'], param['width'],
                                         param['gamma'], param['lambda'],
                                         self.configuration.make_sigmoid(),
-                                        param['eta'], random_state=None)
+                                        param['eta'], random_state=random_state)
         else:
             sigmoid = self.configuration.make_sigmoid()
             out = sigmoid(stimulus_level, threshold=param['threshold'], width=param['width'],

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -175,13 +175,12 @@ class Result:
             Proportion correct values for the fitted psychometric function at the given stimulus levels.
         """
         stimulus_level, param = np.asarray(stimulus_level), self.get_parameter_estimate(estimate_type)
+        sigmoid = self.configuration.make_sigmoid()
         if with_eta:
             out = psychometric_with_eta(stimulus_level, param['threshold'], param['width'],
-                                        param['gamma'], param['lambda'],
-                                        self.configuration.make_sigmoid(),
+                                        param['gamma'], param['lambda'], sigmoid,
                                         param['eta'], random_state=random_state)
         else:
-            sigmoid = self.configuration.make_sigmoid()
             out = sigmoid(stimulus_level, threshold=param['threshold'], width=param['width'],
                           gamma=param['gamma'], lambd=param['lambda'])
 

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -164,7 +164,7 @@ class Result:
 
         Args:
             stimulus_level: stimulus levels.
-            with_eta: if set after computing proportion correct values adds noise
+            with_eta: if set, after computing proportion correct values, add noise
                 to the data so that its variance is compatible with the estimated
                 overdispersion parameter `eta`.
             estimate_type: Type of estimate, either "MAP" or "mean".

--- a/psignifit/_utils.py
+++ b/psignifit/_utils.py
@@ -51,10 +51,12 @@ def check_data(data: np.ndarray) -> np.ndarray:
 
 
 def cast_np_scalar(x):
-    """Cast an object to a Python scalar if it is a numpy scalar.
+    """Cast an object to a Python scalar if it is a numpy scalar or a 0-d numpy array .
 
     The function is a no-op if x is not a numpy scalar."""
     if isinstance(x, np.number):
+        return x.item()
+    elif isinstance(x, np.ndarray) and x.ndim == 0:
         return x.item()
     else:
         return x

--- a/psignifit/tools.py
+++ b/psignifit/tools.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy import stats
 
-from psignifit._utils import check_data
-from psignifit.sigmoids import sigmoid_by_name
-
+from ._utils import check_data
+from .sigmoids import sigmoid_by_name
+from ._utils import cast_np_scalar
 
 def pool_blocks(data: np.ndarray, max_tol=0, max_gap=np.inf, max_length=np.inf):
     """ Pool trials by stimulus level.

--- a/psignifit/tools.py
+++ b/psignifit/tools.py
@@ -52,7 +52,7 @@ def pool_blocks(data: np.ndarray, max_tol=0, max_gap=np.inf, max_length=np.inf):
 
 
 def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
-                          sigmoid_name, eta, random_state=None):
+                          sigmoid, eta, random_state=None):
     """ Psychometric function with overdispersion.
 
     This is a convenience function used mostly for testing and demos. It first computes proportion correct values
@@ -67,8 +67,9 @@ def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
         width: Width of the psychometric function
         gamma: Guess rate
         lambda_: Lapse rate
-        sigmoid_name: Name of sigmoid function to use. See `psignifit.sigmoids.ALL_SIGMOID_NAMES` for the list of
-            available sigmoids
+        sigmoid: A callable, for example a sigmoid function as returned by Configuration.make_sigmoid(), or
+                 a name of the sigmoid function to use. See `psignifit.sigmoids.ALL_SIGMOID_NAMES` for the list of
+                 available sigmoids
         eta: Overdispersion parameter
         random_state: Random state used to generate the additional variance in the data. If None, NumPy's default
             random number generator is used.
@@ -79,7 +80,9 @@ def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
     if random_state is None:
         random_state = np.random.default_rng()
 
-    sigmoid = sigmoid_by_name(sigmoid_name)
+    if type(sigmoid) is str:
+        sigmoid = sigmoid_by_name(sigmoid)
+
     psi = sigmoid(stimulus_level, threshold=threshold, width=width, gamma=gamma, lambd=lambda_)
 
     new_psi = []
@@ -89,4 +92,4 @@ def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
         noised_p = stats.beta.rvs(a=a, b=b, size=1, random_state=random_state)
         new_psi.append(noised_p)
 
-    return np.array(new_psi).squeeze()
+    return cast_np_scalar(np.array(new_psi).squeeze())

--- a/psignifit/tools.py
+++ b/psignifit/tools.py
@@ -86,7 +86,7 @@ def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
     psi = sigmoid(stimulus_level, threshold=threshold, width=width, gamma=gamma, lambd=lambda_)
 
     new_psi = []
-    for p in psi:
+    for p in np.atleast_1d(psi):
         a = ((1/eta**2) - 1) * p
         b = ((1/eta**2) - 1) * (1 - p)
         noised_p = stats.beta.rvs(a=a, b=b, size=1, random_state=random_state)

--- a/psignifit/tools.py
+++ b/psignifit/tools.py
@@ -80,7 +80,7 @@ def psychometric_with_eta(stimulus_level, threshold, width, gamma, lambda_,
     if random_state is None:
         random_state = np.random.default_rng()
 
-    if type(sigmoid) is str:
+    if isinstance(sigmoid, str):
         sigmoid = sigmoid_by_name(sigmoid)
 
     psi = sigmoid(stimulus_level, threshold=threshold, width=width, gamma=gamma, lambd=lambda_)

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -70,6 +70,13 @@ def test_py_not_np_scalar_slope(input_data):
     assert type(value) in (int, float)
 
 
+@pytest.mark.parametrize('with_eta', (True, False))
+def test_py_not_np_scalar_proportion_correct(input_data, with_eta):
+    result = psignifit(input_data[:3,:], experiment_type='yes/no')
+    value = result.proportion_correct(input_data[0,0], with_eta=with_eta)
+    assert type(value) in (int, float)
+
+
 @pytest.mark.parametrize('negative', (True, False))
 @pytest.mark.parametrize('sigmoid_class', ALL_SIGMOID_CLASSES)
 @pytest.mark.parametrize('method', ('__call__', '_value', 'inverse', 'slope'))

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -20,6 +20,11 @@ def test_cast_np_scalar_ndarray_noop():
     assert isinstance(cast, np.ndarray)
 
 
+def test_cast_np_scalar_ndarray_0d():
+    cast = cast_np_scalar(np.array(1))
+    assert isinstance(cast, numbers.Number)
+
+
 @pytest.mark.parametrize('ci_method', ('percentiles', 'project'))
 def test_py_not_np_scalar_ci(input_data, ci_method):
     result = psignifit(input_data[:3,:], experiment_type='yes/no', CI_method=ci_method)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -344,6 +344,7 @@ def test_posterior_samples(result, random_state):
     empirical_posterior = counts / n_samples
     np.testing.assert_allclose(empirical_posterior, posterior, atol=1e-2)
 
+
 def test_result_proportion_correct(result):
     exp = np.linspace(0.2, 0.5, num=1000)
     stimulus_levels = result.threshold(exp, return_ci=False)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -344,3 +344,12 @@ def test_posterior_samples(result, random_state):
     empirical_posterior = counts / n_samples
     np.testing.assert_allclose(empirical_posterior, posterior, atol=1e-2)
 
+def test_result_proportion_correct(result):
+    exp = np.linspace(0.2, 0.5, num=1000)
+    stimulus_levels = result.threshold(exp, return_ci=False)
+    out = result.proportion_correct(stimulus_levels, with_eta=False)
+    np.testing.assert_allclose(exp, out)
+    # we can't really test with_eta properly, but we can make sure
+    # that given a small eta the output is still quite close
+    out = result.proportion_correct(stimulus_levels, with_eta=True)
+    np.testing.assert_allclose(exp, out, rtol=1e-3)


### PR DESCRIPTION
Fixes #64 