### PR TITLE
build docs using oldest supported Python version and add Python 3.13 to CI tests and release workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.13
+          python-version: 3.10
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu]
-        python_version: ['3.10', '3.11', '3.12']
+        python_version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: flake8 Lint Errors
       uses: py-actions/flake8@v2
       with:


### PR DESCRIPTION
Fixes #213 