### PR TITLE
Fixed parms tests

### DIFF
--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -155,6 +155,10 @@ class Configuration:
                     # 0 <= gamma < 1 and 0 <= lambda < 1
                     raise PsignifitException(f'{prefix} 0 <= {parm_name} < 1 {suffix}')
                 # WARNINGS
+                if parm_name == 'lambda' and parm_value > 0.2:
+                    # lambda > 0.2 is unusual
+                    warnings.warn(f"You have fixed the lapse rate lambda to an unusually high value ({parm_value}). "
+                                  f"In typical psychophysical experiments lambda is rarely above 0.2 for human observers.")
 
     def check_experiment_type_matches_fixed_parameters(self, fixed_params, experiment_type):
         if experiment_type == ExperimentType.N_AFC.value:

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -139,7 +139,7 @@ class Configuration:
                 # 0 <= gamma + lambda < 1
                 if not (0 <= gamma+lambda_ < 1):
                     raise PsignifitException(f'For gamma and lambda the condition'
-                                             f' 0 <= gamma + lambda < 1 mut always apply:'
+                                             f' 0 <= gamma + lambda < 1 must always apply:'
                                              f' got gamma={gamma}, lambda={lambda_} instead!')
             for parm_name, parm_value in value.items():
                 # ERRORS

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -165,7 +165,7 @@ class Configuration:
             if fixed_params is not None and 'gamma' in fixed_params:
                 warnings.warn(
                     f'The parameter gamma was fixed to {fixed_params["gamma"]}. In {ExperimentType.N_AFC.value} experiments gamma is automatically fixed to 1/n. Ignoring fixed gamma.')
-        if experiment_type == ExperimentType.EQ_ASYMPTOTE.value:
+        elif experiment_type == ExperimentType.EQ_ASYMPTOTE.value:
             if fixed_params is not None:
                 if 'gamma' in fixed_params:
                     pass # we assume the user knows what they are doing
@@ -177,6 +177,12 @@ class Configuration:
                             f'The parameters lambda {fixed_params["lambda"]} and'
                             f' gamma {fixed_params["gamma"]} were fixed to different values.'
                             f' In {experiment_type} experiments gamma and lambda need to be equal. ')
+        elif experiment_type == ExperimentType.YES_NO.value and fixed_params is not None:
+            if (gamma := fixed_params.get('gamma')) and gamma > 0.2:
+                    # gamma > 0.2 for yes/no experiments is unusual
+                    warnings.warn(f"You have fixed the guess rate gamma to an unusually high value ({gamma}). "
+                                  f"In typical psychophysical experiment of type 'yes/no' gamma is "
+                                  f"rarely above 0.2 for human observers.")
 
 
     def check_experiment_type(self, value):

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -134,13 +134,6 @@ class Configuration:
                     f'Option fixed_parameters keys must be in {vkeys}. Given {list(value.keys())}!'
                 )
             # Check that the fixed parameters have been set to meaningful values
-            if (gamma := value.get('gamma')) and (lambda_ := value.get('lambda')):
-                # this condition can only happen if both lambda and gamma are fixed
-                # 0 <= gamma + lambda < 1
-                if not (0 <= gamma+lambda_ < 1):
-                    raise PsignifitException(f'For gamma and lambda the condition'
-                                             f' 0 <= gamma + lambda < 1 must always apply:'
-                                             f' got gamma={gamma}, lambda={lambda_} instead!')
             for parm_name, parm_value in value.items():
                 # ERRORS
                 prefix = f'Fixed parameter {parm_name} must be strictly'
@@ -159,6 +152,16 @@ class Configuration:
                     # lambda > 0.2 is unusual
                     warnings.warn(f"You have fixed the lapse rate lambda to an unusually high value ({parm_value}). "
                                   f"In typical psychophysical experiments lambda is rarely above 0.2 for human observers.")
+
+            if 'gamma' in value and 'lambda' in value:
+                gamma, lambda_ = value['gamma'], value['lambda']
+                # this condition can only happen if both lambda and gamma are fixed
+                # 0 <= gamma + lambda < 1
+                if not (0 <= gamma+lambda_ < 1):
+                    raise PsignifitException(f'For gamma and lambda the condition'
+                                             f' 0 <= gamma + lambda < 1 must always apply:'
+                                             f' got gamma={gamma}, lambda={lambda_} instead!')
+
 
     def check_experiment_type_matches_fixed_parameters(self, fixed_params, experiment_type):
         if experiment_type == ExperimentType.N_AFC.value:

--- a/psignifit/_configuration.py
+++ b/psignifit/_configuration.py
@@ -131,9 +131,30 @@ class Configuration:
             vkeys = _PARAMETERS
             if vkeys < set(value.keys()):
                 raise PsignifitException(
-                    f'Option fixed_paramters keys must be in {vkeys}. Given {list(value.keys())}!'
+                    f'Option fixed_parameters keys must be in {vkeys}. Given {list(value.keys())}!'
                 )
-
+            # Check that the fixed parameters have been set to meaningful values
+            if (gamma := value.get('gamma')) and (lambda_ := value.get('lambda')):
+                # this condition can only happen if both lambda and gamma are fixed
+                # 0 <= gamma + lambda < 1
+                if not (0 <= gamma+lambda_ < 1):
+                    raise PsignifitException(f'For gamma and lambda the condition'
+                                             f' 0 <= gamma + lambda < 1 mut always apply:'
+                                             f' got gamma={gamma}, lambda={lambda_} instead!')
+            for parm_name, parm_value in value.items():
+                # ERRORS
+                prefix = f'Fixed parameter {parm_name} must be strictly'
+                suffix = f': got {parm_name}={parm_value} instead!'
+                if parm_name == 'width' and parm_value <= 0:
+                    # 0 < width < +inf
+                    raise PsignifitException(f'{prefix} > 0 {suffix}')
+                elif parm_name == 'eta' and not(0 <= parm_value <= 1):
+                    # 0 <= eta <= 1
+                    raise PsignifitException(f'{prefix} 0 <= eta <= 1 {suffix}')
+                elif parm_name in ('gamma', 'lambda') and not(0 <= parm_value < 1):
+                    # 0 <= gamma < 1 and 0 <= lambda < 1
+                    raise PsignifitException(f'{prefix} 0 <= {parm_name} < 1 {suffix}')
+                # WARNINGS
 
     def check_experiment_type_matches_fixed_parameters(self, fixed_params, experiment_type):
         if experiment_type == ExperimentType.N_AFC.value:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -167,6 +167,7 @@ def test_fixed_parm_gamma():
     with pytest.warns(UserWarning, match='unusual'):
         Configuration(fixed_parameters={'gamma': 0.2+EPSPOS}, experiment_type='yes/no')
 
+
 def test_fixed_parm_lambda():
     # 0 <= lambda < 1
     with pytest.raises(PsignifitException, match='lambda'):
@@ -182,5 +183,9 @@ def test_fixed_parm_gamma_lambda():
     # 0 <= gamma + lambda < 1
     with pytest.raises(PsignifitException, match=r'gamma \+ lambda'):
         Configuration(fixed_parameters={'gamma': 0.9, 'lambda': 0.2})
-
-
+    # gamma == 0 and lambda == 2 should fail!
+    with pytest.raises(PsignifitException):
+        Configuration(fixed_parameters={'gamma': 0, 'lambda': 2})
+    # gamma == 2 and lambda == 0 should fail!
+    with pytest.raises(PsignifitException):
+        Configuration(fixed_parameters={'gamma': 2, 'lambda': 0})

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -171,10 +171,14 @@ def test_fixed_parm_lambda():
     # lambda > 0.2 is unusual
     with pytest.warns(UserWarning, match='unusual'):
         Configuration(fixed_parameters={'lambda': 0.3})
+    # gamma > 0.2 and yes/no is unusual
+    with pytest.warns(UserWarning, match='unusual'):
+        Configuration(fixed_parameters={'gamma': 0.3}, experiment_type='yes/no')
 
 
 def test_fixed_parm_gamma_lambda():
     # 0 <= gamma + lambda < 1
     with pytest.raises(PsignifitException, match=r'gamma \+ lambda'):
         Configuration(fixed_parameters={'gamma': 0.9, 'lambda': 0.2})
+
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,11 +1,14 @@
 import dataclasses
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from psignifit._configuration import Configuration
 from psignifit._utils import PsignifitException
 
+EPSNEG = -np.finfo(np.float64).epsneg
+EPSPOS = np.finfo(np.float64).eps
 
 def test_setting_valid_option():
     c = Configuration(verbose=20)
@@ -143,37 +146,37 @@ def test_fixed_parm_width():
     with pytest.raises(PsignifitException, match='width'):
         Configuration(fixed_parameters={'width': 0})
     with pytest.raises(PsignifitException, match='width'):
-        Configuration(fixed_parameters={'width': -1})
+        Configuration(fixed_parameters={'width': EPSNEG})
 
 
 def test_fixed_parm_eta():
     # 0 <= eta <= 1
     with pytest.raises(PsignifitException, match='eta'):
-        Configuration(fixed_parameters={'eta': -1})
+        Configuration(fixed_parameters={'eta': EPSNEG})
     with pytest.raises(PsignifitException, match='eta'):
-        Configuration(fixed_parameters={'eta': 2})
+        Configuration(fixed_parameters={'eta': 1+EPSPOS})
 
 
 def test_fixed_parm_gamma():
     # 0 <= gamma < 1
     with pytest.raises(PsignifitException, match='gamma'):
-        Configuration(fixed_parameters={'gamma': -1})
+        Configuration(fixed_parameters={'gamma': EPSNEG})
     with pytest.raises(PsignifitException, match='gamma'):
-        Configuration(fixed_parameters={'gamma': 2})
+        Configuration(fixed_parameters={'gamma': 1})
 
 
 def test_fixed_parm_lambda():
     # 0 <= lambda < 1
     with pytest.raises(PsignifitException, match='lambda'):
-        Configuration(fixed_parameters={'lambda': -1})
+        Configuration(fixed_parameters={'lambda': EPSNEG})
     with pytest.raises(PsignifitException, match='lambda'):
-        Configuration(fixed_parameters={'lambda': 2})
+        Configuration(fixed_parameters={'lambda': 1})
     # lambda > 0.2 is unusual
     with pytest.warns(UserWarning, match='unusual'):
-        Configuration(fixed_parameters={'lambda': 0.3})
+        Configuration(fixed_parameters={'lambda': 0.2+EPSPOS})
     # gamma > 0.2 and yes/no is unusual
     with pytest.warns(UserWarning, match='unusual'):
-        Configuration(fixed_parameters={'gamma': 0.3}, experiment_type='yes/no')
+        Configuration(fixed_parameters={'gamma': 0.2+EPSPOS}, experiment_type='yes/no')
 
 
 def test_fixed_parm_gamma_lambda():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -138,3 +138,40 @@ def test_warning_for_equal_asymptote_fixing_lambda_and_gamma():
         Configuration(**options)
 
 
+def test_fixed_parm_width():
+    # 0 < width < +inf
+    with pytest.raises(PsignifitException, match='width'):
+        Configuration(fixed_parameters={'width': 0})
+    with pytest.raises(PsignifitException, match='width'):
+        Configuration(fixed_parameters={'width': -1})
+
+
+def test_fixed_parm_eta():
+    # 0 <= eta <= 1
+    with pytest.raises(PsignifitException, match='eta'):
+        Configuration(fixed_parameters={'eta': -1})
+    with pytest.raises(PsignifitException, match='eta'):
+        Configuration(fixed_parameters={'eta': 2})
+
+
+def test_fixed_parm_gamma():
+    # 0 <= gamma < 1
+    with pytest.raises(PsignifitException, match='gamma'):
+        Configuration(fixed_parameters={'gamma': -1})
+    with pytest.raises(PsignifitException, match='gamma'):
+        Configuration(fixed_parameters={'gamma': 2})
+
+
+def test_fixed_parm_lambda():
+    # 0 <= lambda < 1
+    with pytest.raises(PsignifitException, match='lambda'):
+        Configuration(fixed_parameters={'lambda': -1})
+    with pytest.raises(PsignifitException, match='lambda'):
+        Configuration(fixed_parameters={'lambda': 2})
+
+
+def test_fixed_parm_gamma_lambda():
+    # 0 <= gamma + lambda < 1
+    with pytest.raises(PsignifitException, match=r'gamma \+ lambda'):
+        Configuration(fixed_parameters={'gamma': 0.9, 'lambda': 0.2})
+

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -163,7 +163,9 @@ def test_fixed_parm_gamma():
         Configuration(fixed_parameters={'gamma': EPSNEG})
     with pytest.raises(PsignifitException, match='gamma'):
         Configuration(fixed_parameters={'gamma': 1})
-
+    # gamma > 0.2 and yes/no is unusual
+    with pytest.warns(UserWarning, match='unusual'):
+        Configuration(fixed_parameters={'gamma': 0.2+EPSPOS}, experiment_type='yes/no')
 
 def test_fixed_parm_lambda():
     # 0 <= lambda < 1
@@ -174,9 +176,6 @@ def test_fixed_parm_lambda():
     # lambda > 0.2 is unusual
     with pytest.warns(UserWarning, match='unusual'):
         Configuration(fixed_parameters={'lambda': 0.2+EPSPOS})
-    # gamma > 0.2 and yes/no is unusual
-    with pytest.warns(UserWarning, match='unusual'):
-        Configuration(fixed_parameters={'gamma': 0.2+EPSPOS}, experiment_type='yes/no')
 
 
 def test_fixed_parm_gamma_lambda():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -168,6 +168,9 @@ def test_fixed_parm_lambda():
         Configuration(fixed_parameters={'lambda': -1})
     with pytest.raises(PsignifitException, match='lambda'):
         Configuration(fixed_parameters={'lambda': 2})
+    # lambda > 0.2 is unusual
+    with pytest.warns(UserWarning, match='unusual'):
+        Configuration(fixed_parameters={'lambda': 0.3})
 
 
 def test_fixed_parm_gamma_lambda():

--- a/tests/test_numpy_scalars.py
+++ b/tests/test_numpy_scalars.py
@@ -36,7 +36,7 @@ def test_py_not_np_scalar_ci(input_data, ci_method):
 
 @pytest.mark.parametrize('fixed_parm', [(None, None),
                                         ('lambda', 3e-7),
-                                        ('gamma', 0.5),
+                                        ('gamma', 0.1),
                                         ('eta', 1e-4),
                                         ('threshold', 0.0046),
                                         ('width', 0.0046)])

--- a/tests/test_param_recovery.py
+++ b/tests/test_param_recovery.py
@@ -115,7 +115,10 @@ def test_parameter_recovery_fixed_params(fixed_param):
     # we fix it to a slightly off value, so we can check if stays fixed
     options['fixed_parameters'][fixed_param] = sim_params[fixed_param]
 
-    res = psignifit(data, **options)
+    with warnings.catch_warnings():
+        # ignore warning about gamma behind unusual
+        warnings.simplefilter("ignore")
+        res = psignifit(data, **options)
     # check fixed params are not touched
     assert res.parameter_estimate_MAP[fixed_param] == sim_params[fixed_param]
 


### PR DESCRIPTION
Error and warning messages and sensible bounds for the parameters were discussed with @FelixWichmann .

Fixes #221
