### PR TITLE
Fixes timeout issue happening sometimes when building the docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ copyright: "2024. Licence: GPLv2"  # Copyright year to be placed in the footer
 
 execute:
   execute_notebooks: force
+  timeout: -1
 
 #only_build_toc_files        : true
 
@@ -51,6 +52,7 @@ sphinx:
      "member-order": 'bysource',     # Order members as in source file.
     }
     exclude_patterns: ['_build']
+    nb_execution_show_tb: True
     intersphinx_mapping:
         python:
           - 'https://docs.python.org/3/'


### PR DESCRIPTION
it also changes the configuration to that the trackeback from erros are printed directly and not stored in logs which we cannot access when building it in a CI server

Fixes #223 