### PR TITLE
Adapts threshold method to return worse-case confidence intervals correctly

### DIFF
--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -124,8 +124,7 @@ class Result:
             proportion_correct_unscaled = proportion_correct
         else:
             lambd, gamma = estimate['lambda'], estimate['gamma']
-            proportion_correct_unscaled = (proportion_correct - gamma)/(1- lambd - gamma)
-            
+            proportion_correct_unscaled = (proportion_correct - gamma)/(1- lambd - gamma)     
         new_threshold = sigmoid.inverse(proportion_correct, estimate['threshold'],
                                         estimate['width'], gamma, lambd)
         if not return_ci:

--- a/psignifit/_result.py
+++ b/psignifit/_result.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 from typing import Any, Dict, Tuple, List, Optional, TextIO, Union
 from pathlib import Path
+import warnings
 
 import numpy as np
 from numpy.typing import NDArray
@@ -115,6 +116,19 @@ class Result:
             (thresholds, ci): stimulus values along with confidence intervals
 
         """
+        if return_ci:
+            warnings.warn("""The confidence intervals computed by this method are only upper bounds. 
+                          To get a more accurate confidence interval at another level of proportion 
+                          correct, you need to redefine the threshold, that is, refine at which level
+                          the threshold parameter is set. You can do that by changing the argument 
+                          'thresh_PC', and call psignifit again. For an example, see documentation, 
+                          page "Advanced options").
+                          
+                          If instead you want to get the range of uncertainty for the psychometric 
+                          function fit, then you need to sample from the posterior and visualize those 
+                          samples. The function plot_posterior_samples in psigniplot does exactly that.
+                          You find an example of that visualization in the documentation, page Plotting""")
+
         proportion_correct = np.asarray(proportion_correct)
         sigmoid = self.configuration.make_sigmoid()
 


### PR DESCRIPTION
Partially fixes #191 

However, the function does not take a vectorized form for proportion_correct

And the tests need to be changed, the expected values were manually changed.

I need help with that, could you help @pberkes ?