### PR TITLE
Add test to reproduce issue #243, and fix

### DIFF
--- a/psignifit/tools.py
+++ b/psignifit/tools.py
@@ -34,9 +34,11 @@ def pool_blocks(data: np.ndarray, max_tol=0, max_gap=np.inf, max_length=np.inf):
             block = []
             gap = 0
             for j in range(i, ndata):
-                if (cum_ntrials[j + 1] -
-                        cum_ntrials[i]) > max_length or gap > max_gap:
+                # j > i condition: make sure there is at least one data point per block
+                if ((cum_ntrials[j + 1] - cum_ntrials[i]) > max_length
+                        or gap > max_gap) and j > i:
                     break
+
                 level, ncorrect, ntrials = data[j, :]
                 if abs(level - current) <= max_tol and not seen[j]:
                     seen[j] = True

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -125,8 +125,6 @@ def test_pooling_243():
         [400, 80, 80]
     ])
 
-    # Crashes with:
-    # TypeError: cannot unpack non-iterable numpy.float64 object
     pooled = pool_blocks(data, max_tol=50, max_gap=50, max_length=10)
     assert np.allclose(pooled, data)
 

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -112,6 +112,25 @@ def test_pooling_big_max_gap():
     assert np.allclose(exp, act, rtol=0, atol=1e-04)
 
 
+def test_pooling_243():
+    # Reproduces issue #243
+
+    data = np.array([
+        [100, 50, 50],
+        [101, 51, 51],
+        [200, 60, 60],
+        [201, 61, 61],
+        [300, 70, 70],
+        [301, 71, 71],
+        [400, 80, 80]
+    ])
+
+    # Crashes with:
+    # TypeError: cannot unpack non-iterable numpy.float64 object
+    pooled = pool_blocks(data, max_tol=50, max_gap=50, max_length=10)
+    assert np.allclose(pooled, data)
+
+
 data = np.array([
     [1.3262, 1, 1],
     [0.8534, 1, 1],


### PR DESCRIPTION
Fix #243 

We need to make sure that there is at least one line in each block. The fix matches the condition in the Matlab source core
https://github.com/wichmann-lab/psignifit/blob/5f7241f6288c7dd3e1b34353118ca919ad28e51b/private/poolData.m#L32